### PR TITLE
Add audio_url API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ establish a session, please see [clients.py](https://github.com/iwalton3/jellyfi
    - `get_season` for fetching season metadata.
    - `get_audio_stream` to read an audio stream into a file
    - `search_media_items` to search for media items
+   - `audio_url` to return the URL to an audio file
  - Add parameters `aid=None, sid=None, start_time_ticks=None, is_playback=True` to API call `get_play_info`.
  - Add timesync manager and SyncPlay API methods.
 

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -49,6 +49,11 @@ class API(object):
         request.update({'type': action, 'handler': url})
 
         return self.client.request(request)
+    
+    def _http_url(self, action, url, request={}):
+        request.update({"type": action, "handler": url})
+
+        return self.client.request_url(request)
 
     def _http_stream(self, action, url, dest_file, request={}):
         request.update({'type': action, 'handler': url})
@@ -57,6 +62,9 @@ class API(object):
 
     def _get(self, handler, params=None):
         return self._http("GET", handler, {'params': params})
+
+    def _get_url(self, handler, params=None):
+        return self._http_url("GET", handler, {"params": params})
 
     def _post(self, handler, json=None, params=None):
         return self._http("POST", handler, {'params': params, 'json': json})
@@ -110,10 +118,21 @@ class API(object):
         return self._get("Videos%s" % handler)
 
     def artwork(self, item_id, art, max_width, ext="jpg", index=None):
-        if index is None:
-            return jellyfin_url(self.client, "Items/%s/Images/%s?MaxWidth=%s&format=%s" % (item_id, art, max_width, ext))
+        params = {"MaxWidth": max_width, "format": ext}
+        handler = ("Items/%s/Images/%s" % (item_id, art) if index is None
+            else "Items/%s/Images/%s/%s" % (item_id, art, index)
+        )
 
-        return jellyfin_url(self.client, "Items/%s/Images/%s/%s?MaxWidth=%s&format=%s" % (item_id, art, index, max_width, ext))
+        return self._get_url(handler, params)
+
+    def audio_url(self, item_id, max_streaming_bitrate=140000000):
+        params = {
+            "UserId": "{UserId}",
+            "DeviceId": "{DeviceId}",
+            "MaxStreamingBitrate": max_streaming_bitrate,
+        }
+
+        return self._get_url("Audio/%s/universal" % item_id, params)
 
     #################################################################################################
 

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -6,6 +6,7 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 import json
 import logging
 import time
+import urllib
 
 import requests
 from six import string_types
@@ -69,6 +70,19 @@ class HTTP(object):
                 LOG.debug("DeviceId is not set.")
 
         return string
+
+    def request_url(self, data):
+        if not data:
+            raise AttributeError("Request cannot be empty")
+
+        data = self._request(data)
+        
+        params = data["params"]
+        if "api_key" not in params:
+            params["api_key"] = self.config.data.get('auth.token')
+
+        encoded_params = urllib.parse.urlencode(data["params"])
+        return "%s?%s" % (data["url"], encoded_params)
 
     def request(self, data, session=None, dest_file=None):
 


### PR DESCRIPTION
This PR introduces a new API call, "audio_url" that will return a URL to an audio file for the currently authenticated user.
This allows external clients to request an access URL to an audio file in order to play it using an external player.

This will be used to simply the Home Assistant integration I am currently trying to get merged.

I've also rewritten the artwork API call to use the same supporting methods I added to support the audio_url call.

If this PR is accepted, I'll try to introduce similar API calls to return access URLs to other media types.