### PR TITLE
Adding video_url and download_url

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -134,6 +134,20 @@ class API(object):
 
         return self._get_url("Audio/%s/universal" % item_id, params)
 
+    def video_url(self, item_id, media_source_id=None):
+        params = {
+            "static": "true",
+            "DeviceId": "{DeviceId}"
+        }
+        if media_source_id is not None:
+            params["MediaSourceId"] = media_source_id
+
+        return self._get_url("Videos/%s/stream" % item_id, params)
+
+    def download_url(self, item_id):
+        params = {}
+        return self._get_url("Items/%s/Download" % item_id, params)
+
     #################################################################################################
 
     # More granular api


### PR DESCRIPTION
This shouldn't have taken so long, but I thought there would be more getter URLs to add.
As far as I can see in terms of accessing actual media this is it (looking at how the web client uses the API):
- For audio the audio_url is used
- For video the video_url is used
- For pictures the download_url is used
- For Live TV the video_url is used

For LiveTV I also see a LiveTv/LiveStreamFiles/{streamId}/stream.{container} API call, but that does not seem to be used, nor does it work on my instance.