### PR TITLE
clean up logging and allign stream_url and url_getter

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, print_function, unicode_literals
 from datetime import datetime
-import re
 import requests
 import json
 import logging
@@ -125,10 +124,12 @@ class API(object):
 
         return self._get_url(handler, params)
 
-    def audio_url(self, item_id, max_streaming_bitrate=140000000):
+    def audio_url(self, item_id, container, audio_codec=None, max_streaming_bitrate=140000000):
         params = {
             "UserId": "{UserId}",
             "DeviceId": "{DeviceId}",
+            'Container': container,
+            'AudioCodec': audio_codec,
             "MaxStreamingBitrate": max_streaming_bitrate,
         }
 
@@ -429,7 +430,8 @@ class API(object):
             'DeviceId': "{DeviceId}",
             'PlaySessionId': play_id,
             'Container': container,
-            'AudioCodec': audio_codec
+            'AudioCodec': audio_codec,
+            "MaxStreamingBitrate": max_streaming_bitrate,
         })
 
     def get_default_headers(self):
@@ -466,7 +468,11 @@ class API(object):
         LOG.debug(request_settings['timeout'])
         LOG.debug(request_settings['headers'])
 
-        return request_method(url, **request_settings)
+        try:
+            return request_method(url, **request_settings)
+        except requests.exceptions.RequestException as error:
+            LOG.error(error)
+
 
 
     def login(self, server_url, username, password=""):
@@ -498,8 +504,6 @@ class API(object):
         return {}
 
     def validate_authentication_token(self, server):
-
-        url = "%s/%s" % (server['address'], "system/info")
         authTokenHeader = {
                     'X-MediaBrowser-Token': server['AccessToken']
                 }

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -124,14 +124,18 @@ class API(object):
 
         return self._get_url(handler, params)
 
-    def audio_url(self, item_id, container, audio_codec=None, max_streaming_bitrate=140000000):
+    def audio_url(self, item_id, container=None, audio_codec=None, max_streaming_bitrate=140000000):
         params = {
             "UserId": "{UserId}",
             "DeviceId": "{DeviceId}",
-            'Container': container,
-            'AudioCodec': audio_codec,
             "MaxStreamingBitrate": max_streaming_bitrate,
         }
+
+        if container:
+            params["Container"] = container
+
+        if audio_codec:
+            params["AudioCodec"] = audio_codec
 
         return self._get_url("Audio/%s/universal" % item_id, params)
 
@@ -468,12 +472,7 @@ class API(object):
         LOG.debug(request_settings['timeout'])
         LOG.debug(request_settings['headers'])
 
-        try:
-            return request_method(url, **request_settings)
-        except requests.exceptions.RequestException as error:
-            LOG.error(error)
-
-
+        return request_method(url, **request_settings)
 
     def login(self, server_url, username, password=""):
         path = "Users/AuthenticateByName"

--- a/jellyfin_apiclient_python/connection_manager.py
+++ b/jellyfin_apiclient_python/connection_manager.py
@@ -6,14 +6,12 @@ from __future__ import division, absolute_import, print_function, unicode_litera
 import json
 import logging
 import socket
-import time
 from datetime import datetime
 from operator import itemgetter
 
 import urllib3
 
 from .credentials import Credentials
-from .http import HTTP  # noqa: I201,I100
 from .api import API
 import traceback
 
@@ -156,25 +154,24 @@ class ConnectionManager(object):
             response_url = self.API.check_redirect(address)
             if address != response_url:
                 address = response_url
-            LOG.info("connectToAddress %s succeeded", address)
+            LOG.info("connect_to_address %s succeeded", address)
             server = {
                 'address': address,
             }
             server = self.connect_to_server(server, options)
             if server is False:
-                LOG.error("connectToAddress %s failed", address)
+                LOG.error("connect_to_address %s failed", address)
                 return { 'State': CONNECTION_STATE['Unavailable'] }
 
             return server
-        except Exception as error:
-            LOG.exception(error)
-            LOG.error("connectToAddress %s failed", address)
+        except Exception:
+            LOG.error("connect_to_address %s failed", address)
             return { 'State': CONNECTION_STATE['Unavailable'] }
 
 
     def connect_to_server(self, server, options={}):
 
-        LOG.info("begin connectToServer")
+        LOG.info("begin connect_to_server")
 
         try:
             result = self.API.get_public_info(server.get('address'))


### PR DESCRIPTION
I've cleaned up some logging, primarily by not printing an entire stack track but just printing the error that causes HTTP issues.
I've also removed some unused imports and aligned the audio url getter method with its stream counterparts.
The omission of the container parameter caused playback issues for some users.