### PR TITLE
Remove use of six module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ establish a session, please see [clients.py](https://github.com/iwalton3/jellyfi
    - `audio_url` to return the URL to an audio file
  - Add parameters `aid=None, sid=None, start_time_ticks=None, is_playback=True` to API call `get_play_info`.
  - Add timesync manager and SyncPlay API methods.
+ - Remove usage of `six` module.
 
 ## Contributing
 

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -9,7 +9,6 @@ import time
 import urllib
 
 import requests
-from six import string_types
 
 from .exceptions import HTTPException
 
@@ -218,7 +217,7 @@ class HTTP(object):
             if isinstance(value, dict):
                 self._process_params(value)
 
-            if isinstance(value, string_types):
+            if isinstance(value, str):
                 params[key] = self._replace_user_info(value)
 
     def _get_header(self, data):

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
-    install_requires=['requests', 'urllib3', 'websocket_client', 'six', 'certifi']
+    install_requires=['requests', 'urllib3', 'websocket_client', 'certifi']
 )


### PR DESCRIPTION
The six module is only for compatibility between Python 2 and 3, and
since the lowest version of Python supported is 3.6, we can remove the
single use of it.