### PR TITLE
Disable Cert Options for none TLS connections

### DIFF
--- a/jellyfin_apiclient_python/ws_client.py
+++ b/jellyfin_apiclient_python/ws_client.py
@@ -67,13 +67,16 @@ class WSClient(threading.Thread):
             self.global_wsc = self.wsc
 
         while not self.stop and not self.global_stop:
-            if not verify:
-                # https://stackoverflow.com/questions/48740053/
-                self.wsc.run_forever(
-                    ping_interval=10, sslopt={"cert_reqs": ssl.CERT_NONE}
-                )
+            if server.startswith('wss'):
+                if not verify:
+                    # https://stackoverflow.com/questions/48740053/
+                    self.wsc.run_forever(
+                        ping_interval=10, sslopt={"cert_reqs": ssl.CERT_NONE}
+                    )
+                else:
+                    self.wsc.run_forever(ping_interval=10, sslopt={"ca_certs": certifi.where()})
             else:
-                self.wsc.run_forever(ping_interval=10, sslopt={"ca_certs": certifi.where()})
+                self.wsc.run_forever(ping_interval=10)
 
             if not self.stop:
                 break


### PR DESCRIPTION
After a recent update. I couldn't connect to my Jellyfin Server via this API Client anymore.

The WS Connection terminated with the error "socket object has no attribute pending" 

I believe this is because we set cert options for non-secure none TSL connections. Secure connections seemed to work just fine even without this change.

Not sure why this only appeared now, but this fixed the issue for me.

