### PR TITLE
Add missing curly bracket in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ And if you wish then use that token to authenticate in future:
 
 ```
 json.loads(credentials)
-client.authenticate({"Servers": [credentials], discover=False)
+client.authenticate({"Servers": [credentials]}, discover=False)
 ```
 
 ### API


### PR DESCRIPTION
My previous commit included a syntax error in the example for authenticating with a token, add the missing curly bracket.