### PR TITLE
Refactor header construction WRT authorization

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -508,21 +508,7 @@ class API(object):
         })
 
     def get_default_headers(self):
-        auth = "MediaBrowser "
-        auth += "Client=%s, " % self.config.data['app.name']
-        auth += "Device=%s, " % self.config.data['app.device_name']
-        auth += "DeviceId=%s, " % self.config.data['app.device_id']
-        auth += "Version=%s" % self.config.data['app.version']
-
-        return {
-            "Accept": "application/json",
-            "Content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-            "X-Application": "%s/%s" % (self.config.data['app.name'], self.config.data['app.version']),
-            "Accept-Charset": "UTF-8,*",
-            "Accept-encoding": "gzip",
-            "User-Agent": self.config.data['http.user_agent'] or "%s/%s" % (self.config.data['app.name'], self.config.data['app.version']),
-            "x-emby-authorization": auth
-        }
+        return self.client._get_default_headers(content_type="application/x-www-form-urlencoded; charset=UTF-8")
 
     def send_request(self, url, path, method="get", timeout=None, headers=None, data=None, session=None):
         request_method = getattr(session or requests, method.lower())
@@ -572,11 +558,8 @@ class API(object):
         return {}
 
     def validate_authentication_token(self, server):
-        authTokenHeader = {
-                    'X-MediaBrowser-Token': server['AccessToken']
-                }
         headers = self.get_default_headers()
-        headers.update(authTokenHeader)
+        headers["Authorization"] += f", Token=\"{server['AccessToken']}\""
 
         response = self.send_request(server['address'], "system/info", headers=headers)
         return response.json() if response.status_code == 200 else {}

--- a/jellyfin_apiclient_python/connection_manager.py
+++ b/jellyfin_apiclient_python/connection_manager.py
@@ -12,6 +12,7 @@ import urllib3
 
 from .credentials import Credentials
 from .api import API
+from .http import HTTP
 import traceback
 
 #################################################################################################
@@ -38,8 +39,7 @@ class ConnectionManager(object):
         self.client = client
         self.config = client.config
         self.credentials = Credentials()
-
-        self.API = API(client)
+        self.API = API(HTTP(client))
 
     def clear_data(self):
 


### PR DESCRIPTION
According to [1], "X-Emby-Authorization" and "X-MediaBrowser-Token" headers are deprecated. Sadly, this is how this library authenticates with a server. Switch to using the Authorization header, but also remove some duplication with header construction so it is only done in the HTTP code. Handle requests that do not include an AccessToken, along with correcting how the connection manager creates its own API object.
    
1: https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f

I have lightly tested this, and can authenticate against the demo server with it. I'd welcome a little more testing before you merge it.