### PR TITLE
Support API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ json.loads(credentials)
 client.authenticate({"Servers": [credentials]}, discover=False)
 ```
 
+You can also authenticate using an API key, which is generated on the server.
+This is different to a device AccessToken, and is set by not configuring a
+device name, or a device id:
+
+```
+client.config.data["app.name"] = 'your_brilliant_app'
+client.config.data["app.version"] = '0.0.1'
+client.authenticate({"Servers": [{"AccessToken: <API key here>, "address": <Server Address>}]}, discover=False)
+```
+
 ### API
 
 The API is accessed via the `jellyfin` attribute of the client. Return values
@@ -83,6 +93,7 @@ The test suite is run via `tox`, and you can install it from PyPi.
  - Remove usage of `six` module.
  - Add group of `remote_` API calls to remote control another session
  - Configurable item refreshes allowing custom refresh logic (can also iterate through a list of items)
+ - Add support for authenticating via an API key
 
 ## Contributing
 

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -653,7 +653,8 @@ class API(object):
 
     def validate_authentication_token(self, server):
         headers = self.get_default_headers()
-        headers["Authorization"] += f", Token=\"{server['AccessToken']}\""
+        comma = "," if "app.device_name" in self.config.data else ""
+        headers["Authorization"] += f"{comma} Token=\"{server['AccessToken']}\""
 
         response = self.send_request(server['address'], "system/info", headers=headers)
         return response.json() if response.status_code == 200 else {}

--- a/jellyfin_apiclient_python/connection_manager.py
+++ b/jellyfin_apiclient_python/connection_manager.py
@@ -87,7 +87,8 @@ class ConnectionManager(object):
             except KeyError:
                 continue
 
-        servers.sort(key=itemgetter('DateLastAccessed'), reverse=True)
+        if len(servers) > 1:
+            servers.sort(key=itemgetter('DateLastAccessed'), reverse=True)
         credentials['Servers'] = servers
         self.credentials.set(credentials)
 
@@ -338,7 +339,8 @@ class ConnectionManager(object):
             if system_info:
 
                 self._update_server_info(server, system_info)
-                self.config.data['auth.user_id'] = server['UserId']
+                if "UserId" in server:
+                    self.config.data['auth.user_id'] = server['UserId']
                 self.config.data['auth.token'] = server['AccessToken']
 
                 return self._after_connect_validated(server, credentials, system_info, False, options)

--- a/jellyfin_apiclient_python/credentials.py
+++ b/jellyfin_apiclient_python/credentials.py
@@ -90,6 +90,8 @@ class Credentials(object):
 
                 if server.get('AccessToken'):
                     existing['AccessToken'] = server['AccessToken']
+
+                if server.get('UserId'):
                     existing['UserId'] = server['UserId']
 
                 if server.get('ExchangeToken'):

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -220,12 +220,14 @@ class HTTP(object):
                 params[key] = self._replace_user_info(value)
 
     def _get_authenication_header(self):
-        params = {
-            "Client": self.config.data['app.name'],
-            "Device": self.config.data['app.device_name'],
-            "DeviceId": self.config.data['app.device_id'],
-            "Version": self.config.data['app.version']
-            }
+        params = {}
+        if "app.device_name" in self.config.data:
+            params.update({
+                "Client": self.config.data['app.name'],
+                "Device": self.config.data['app.device_name'],
+                "DeviceId": self.config.data['app.device_id'],
+                "Version": self.config.data['app.version']
+                })
         if "auth.token" in self.config.data:
             params["Token"] = self.config.data['auth.token']
         param_line = ", ".join(f'{k}="{v}"' for k, v in params.items())


### PR DESCRIPTION
Support also authenticating with an API key -- since this is seperate from device tokens, choose to authenticate with one if a device name is not set.

Fixes #19