### PR TITLE
updated 'refresh_item' with added functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ For details on what the individual API calls do or how to do a certain task, you
  - Add timesync manager and SyncPlay API methods.
  - Remove usage of `six` module.
  - Add group of `remote_` API calls to remote control another session
+ - Configurable item refreshes allowing custom refresh logic (can also iterate through a list of items)
 
 ## Contributing
 


### PR DESCRIPTION
Refresh calls are now customizable when called and also comes with two presets, 'missing' and 'replace', both modeled after requests sent from the Web UI.

The function can now also iterate through a list of items, by passing their ID's in a list.

Default values were retained as to not compromise backwards compatibility.
Also added descriptors for the method.