### PR TITLE
Allow fields query with get_media_folders

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -205,8 +205,11 @@ class API(object):
     def get_views(self):
         return self.users("/Views")
 
-    def get_media_folders(self):
-        return self.users("/Items")
+    def get_media_folders(self, fields=None):
+        params = None
+        if fields is not None:
+            params = {'fields': fields}
+        return self.users("/Items", params=params)
 
     def get_item(self, item_id):
         return self.users("/Items/%s" % item_id)


### PR DESCRIPTION
I found myself in a situation where I needed to get the path corresponding to the top-level media folders. I was able to do this by looking at the source code, realizing it was just an empty call to `self.users("/Items")` and then adding the necessary params to specify the extra fields to returns.

To facilitate my use-case I added a fields option to `get_media_folders`, so running `self.get_media_folders(fields=['Path'])` will now return the associated path with each result.

I'm not sure if this is the best way to go about it, but it worked for me and now I'm putting it up here as a standalone PR for review / comments. 