### PR TITLE
Identify api

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -809,18 +809,19 @@ class ExperimentalAPIMixin:
         """
         Remote search for item metadata given one or more provider id.
 
-        This method requires the user have appropriate permissions
+        This method requires an authenticated user with elevated permissions
+        [RemoveProviderSearch]_.
 
         Args:
-            item_id (str): item uuid to identify
+            item_id (str): item uuid to identify and update metadata for.
 
             provider_ids (Dict):
                 maps providers to the content id. (E.g. {"Imdb": "tt1254207"})
                 Valid keys will depend on available providers. Common ones are:
-                    "Tvdb", "Imdb", "Tvdb".
+                    "Tvdb" and "Imdb".
 
         References:
-            https://api.jellyfin.org/#tag/ItemLookup/operation/ApplySearchCriteria
+            .. [RemoveProviderSearch] https://api.jellyfin.org/#tag/ItemLookup/operation/ApplySearchCriteria
         """
         body = {'ProviderIds': provider_ids}
         return client.jellyfin.items('/RemoteSearch/Apply/' + item_id, action='POST', params=None, json=body)

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -827,7 +827,7 @@ class ExperimentalAPIMixin:
 
 
 class API(InternalAPIMixin, BiggerAPIMixin, GranularAPIMixin,
-          SyncPlayAPIMixin):
+          SyncPlayAPIMixin, ExperimentalAPIMixin):
     """
     The Jellyfin Python API client containing all api calls to the server.
 

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+"""
+For API info see:
+    https://api.jellyfin.org/
+"""
 from typing import List
 from datetime import datetime
 import requests
@@ -794,6 +798,30 @@ class SyncPlayAPIMixin:
         return self._post("SyncPlay/New", {
             "GroupName": group_name
         })
+
+
+class ExperimentalAPIMixin:
+    """
+    This is a location for testing proposed additions to the API Client.
+    """
+
+    def identify(client, item_id, provider_ids):
+        """
+        Remote search for item metadata given one or more provider id.
+
+        This method requires the user have appropriate permissions
+
+        Args:
+            item_id (str): item uuid to identify
+
+            provider_ids (Dict):
+                maps providers to the content id. (E.g. {"Imdb": "tt1254207"})
+
+        References:
+            https://api.jellyfin.org/#tag/ItemLookup/operation/ApplySearchCriteria
+        """
+        body = {'ProviderIds': provider_ids}
+        return client.jellyfin.items('/RemoteSearch/Apply/' + item_id, action='POST', params=None, json=body)
 
 
 class API(InternalAPIMixin, BiggerAPIMixin, GranularAPIMixin,

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -816,6 +816,8 @@ class ExperimentalAPIMixin:
 
             provider_ids (Dict):
                 maps providers to the content id. (E.g. {"Imdb": "tt1254207"})
+                Valid keys will depend on available providers. Common ones are:
+                    "Tvdb", "Imdb", "Tvdb".
 
         References:
             https://api.jellyfin.org/#tag/ItemLookup/operation/ApplySearchCriteria


### PR DESCRIPTION
This adds a new method to the API, which lets the user access the "identify" feature present in the web client.

It took me much longer to figure out how to do this than this diff would suggest. The jellyfin API is... well its an open source project with a lot of technical dept. I'm not sure how to link to the matrix discussion, but the friendly folks in the "Jellyfin Development" room (#jellyfin-dev:matrix.org) were very helpful. The relevant conversation happened in ~2024-Jan-02 T 04:14 PM.

I've marked this as an "experimental" api, because without a testing mechanism in the repo I feel less confident about it. But I have used it, and it does seem to work.

I would like to add a small test suite to this repo that does a quick automated setup of a jellyfin server, and then tests the API against it. Not sure how difficult that will be, but it's something I'm thinking about.