### PR TITLE
Add get/update item metadata methods

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -209,25 +209,36 @@ class GranularAPIMixin:
         return self.users("/Items", params=params)
 
     def get_item(self, item_id):
-        return self.users("/Items/%s" % item_id)
+        """
+        Lookup metadata for an item.
+
+        Args:
+            item_id (str): item uuid to lookup metadata for
+
+        Returns:
+            Dict[str, Any]: metadata keys and values for the queried item.
+        """
+        return self.users("/Items/%s" % item_id, params={
+            'Fields': info()
+        })
 
     def get_items(self, item_ids):
+        """
+        Lookup metadata for multiple items.
+
+        Args:
+            item_ids (List[str]): item uuids to lookup metadata for
+
+        Returns:
+            Dict[str, Any]: A result dictionary where the info from each
+                item is stored in the "Items" list.
+        """
         return self.users("/Items", params={
             'Ids': ','.join(str(x) for x in item_ids),
             'Fields': info()
         })
 
-    def get_item_metadata(self, item_id):
-        """
-        Like :func:`get_item`, but returns all relevant metadata for the item.
-
-        Args:
-            item_id (str): item uuid to lookup metadata for
-        """
-        body = self.get_items([item_id])['Items'][0]
-        return body
-
-    def update_item_metadata(self, item_id, data):
+    def update_item(self, item_id, data):
         """
         Updates the metadata for an item.
 
@@ -237,13 +248,14 @@ class GranularAPIMixin:
             item_id (str): item uuid to update metadata for
 
             data (Dict): the new information to add to this item.
+                Note: any specified items are completely overwritten.
 
         References:
             .. [UpdateItem] https://api.jellyfin.org/#tag/ItemUpdate/operation/UpdateItem
         """
         # Force us to get the entire original item, we need to pass
         # all information, otherwise all info is overwritten
-        body = self.get_item_metadata(item_id)
+        body = self.get_item(item_id)
         body.update(data)
         assert body['Id'] == item_id
         return self.items('/' + item_id, action='POST', params=None, json=body)

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -229,10 +229,17 @@ class GranularAPIMixin:
 
     def update_item_metadata(self, item_id, data):
         """
+        Updates the metadata for an item.
+
+        Requires a user with elevated permissions [UpdateItem]_.
+
         Args:
             item_id (str): item uuid to update metadata for
 
             data (Dict): the new information to add to this item.
+
+        References:
+            .. [UpdateItem] https://api.jellyfin.org/#tag/ItemUpdate/operation/UpdateItem
         """
         # Force us to get the entire original item, we need to pass
         # all information, otherwise all info is overwritten

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -217,6 +217,30 @@ class GranularAPIMixin:
             'Fields': info()
         })
 
+    def get_item_metadata(self, item_id):
+        """
+        Like :func:`get_item`, but returns all relevant metadata for the item.
+
+        Args:
+            item_id (str): item uuid to lookup metadata for
+        """
+        body = self.get_items([item_id])['Items'][0]
+        return body
+
+    def update_item_metadata(self, item_id, data):
+        """
+        Args:
+            item_id (str): item uuid to update metadata for
+
+            data (Dict): the new information to add to this item.
+        """
+        # Force us to get the entire original item, we need to pass
+        # all information, otherwise all info is overwritten
+        body = self.get_item_metadata(item_id)
+        body.update(data)
+        assert body['Id'] == item_id
+        return self.items('/' + item_id, action='POST', params=None, json=body)
+
     def get_sessions(self):
         return self.sessions(params={'ControllableByUserId': "{UserId}"})
 


### PR DESCRIPTION
Related to https://github.com/jellyfin/jellyfin-apiclient-python/pull/40 I spent way to much time figuring out how to use the API to update item metadata. Relevant discussion is on #jellyfin-dev:matrix.org on 2024-Jan-02. (If there is a way to link to a matrix conversation, let me know).

There is a jellyfin architecture quirk that makes this implementation less than ideal. It turns out that when you call the [UpdateItem](https://api.jellyfin.org/#tag/ItemUpdate/operation/UpdateItem) endpoint, any data you don't provide is overwritten with null, so we are stuck with one of two bad options:

1. Force the user to provide all item metadata fields, even if they don't want to update them.
2. Perform a query before we post the update to construct a well-formed request behind the scenes.

For ease of use, I opted for the second option, but raised another issue: there isn't a an easy API call to get metadata for a single item. There is a `get_item`, but it doesn't return all of the fields required by the update method. The `get_items` call does do this, but you have to call it with a list of 1 and then unpack it, which is kinda awkward. I made this problem worse by adding a 3rd method `get_item_metadata` as a stopgap, but I don't want to merge it and add to API bloat.

Fortunately, this problem can likely be solved by updating the `get_item` call to pass `"Fields": info()` in its params dictionary, but I wanted to discuss it first before I did it. Similarly, I'd also like to discuss the name `update_item_metadata`, which I chose just to let me move forward and modify my library, but it's name doesn't agree with the rest of the API.

My current thoughts are to take the following actions:

Remove `get_item_metadata` and change `get_item` to either:

```python
    def get_item(self, item_id):
        return self.users("/Items/%s" % item_id, params={
            'Fields': info()
        })
```

Or let the user pass in Fields if necessary:

```python
    def get_item(self, item_id, params=None):
        return self.users("/Items/%s" % item_id, params=params)
```

Then rename `update_item_metadata` to `update_item` and keep the same signature.

But there are other directions I could go, so I'd like to discuss before I move further. In the meantime this stop-gap API works well enough for me. 
