### PR TITLE
Add support for the optional 'date played' parameter in item_played.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The test suite is run via `tox`, and you can install it from PyPi.
  - Add group of `remote_` API calls to remote control another session
  - Configurable item refreshes allowing custom refresh logic (can also iterate through a list of items)
  - Add support for authenticating via an API key
+ - Add support for the optional 'date played' parameter in the `item_played` API method 
 
 ## Contributing
 

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -619,8 +619,11 @@ class GranularAPIMixin:
     def remote_unmute(self, id):
         return self.command(id, "Unmute")
 
-    def item_played(self, item_id, watched):
-        return self.users("/PlayedItems/%s" % item_id, "POST" if watched else "DELETE")
+    def item_played(self, item_id, watched, date=None):
+        params = {}
+        if watched and date is not None:
+            params["datePlayed"] = date
+        return self.users("/PlayedItems/%s" % item_id, "POST" if watched else "DELETE", params=params)
 
     def get_sync_queue(self, date, filters=None):
         return self._get("Jellyfin.Plugin.KodiSyncQueue/{UserId}/GetItems", params={


### PR DESCRIPTION
The Jellyfin API endpoint `/PlayedItems` accepts an optional parameter, `datePlayed`.

If the item specified in the API call is `watched` in the jellyfin-api-client `item_played` call, and the caller passes a date value, then UserData["LastPlayedDate"] is set to that date (along with the other changes already made by the endpoint).

This is useful in a project I'm working on to synchronise user data between media servers, Jellyfin being one of them.

Tox tests all pass and the linter is happy.