### PR TITLE
Amend get_next

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -343,13 +343,16 @@ class GranularAPIMixin:
             'Fields': info()
         })
 
-    def get_next(self, index=None, limit=1):
-        return self.shows("/NextUp", {
-            'Limit': limit,
-            'UserId': "{UserId}",
-            'StartIndex': None if index is None else int(index)
-        })
-
+    def get_next(self, userId=None, index=None, limit=1, seriesId=None):
+        return self.shows(
+            '/NextUp',
+            {
+                'Limit': limit,
+                'UserId': '{UserId}' if userId is None else userId,
+                'StartIndex': None if index is None else int(index),
+                'SeriesId': None if seriesId is None else seriesId,
+            },
+        )
     def get_adjacent_episodes(self, show_id, item_id):
         return self.shows("/%s/Episodes" % show_id, {
             'UserId': "{UserId}",


### PR DESCRIPTION
Amend the get_next function which calls /Shows/NextUp to include an optional seriesid and userid parameter. 

This will allow you to retrieve the next up just for a specific series rather than all series, as well as getting the next up for a specific user rather than being limited to the user currently logged in.

Before I go down a rabbit hole with this as I have more changes I'd like to make. What's your opinion about allowing the user to specify a userid in the request rather than always using the current logged in user? I feel as an admin user logged in I should be able to retrieve information about any user rather than just the user I am logged in as. If you can already do this and I've missed it then let me know.