### PR TITLE
Add get and update API calls for an item's UserData

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ The test suite is run via `tox`, and you can install it from PyPi.
  - Add group of `remote_` API calls to remote control another session
  - Configurable item refreshes allowing custom refresh logic (can also iterate through a list of items)
  - Add support for authenticating via an API key
- - Add support for the optional 'date played' parameter in the `item_played` API method 
+ - Add support for the optional 'date played' parameter in the `item_played` API method
+ - Add API calls `get_userdata_for_item` and `update_userdata_for_item`
 
 ## Contributing
 

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -508,6 +508,29 @@ class GranularAPIMixin:
             'Fields': info()
         })
 
+    def get_userdata_for_item(self, item_id):
+        return self._get(
+            f"UserItems/{item_id}/UserData", params={"UserId": "{UserId}"}
+        )
+
+    def update_userdata_for_item(self, item_id, data):
+        """
+        Updates the userdata for an item.
+
+        Args:
+            item_id (str): item uuid to update userdata for
+
+            data (dict): the information to add to the current user's 
+                userdata for the item. Any fields in data overwrite the
+                equivalent fields in UserData, other UserData fields are
+                left untouched.
+
+        References:
+            .. [UpdateItemUserData] https://api.jellyfin.org/#tag/Items/operation/UpdateItemUserData
+        """        
+        return self._post(f"UserItems/{item_id}/UserData", params={"UserId": "{UserId}"}, json=data)
+
+
     def refresh_item(self, item_id, recursive=True, image_refresh='FullRefresh', metadata_refresh='FullRefresh', replace_images=False, replace_metadata=True, preset=None):
         """
         Description:


### PR DESCRIPTION
I need to be able to retrieve and optionally update UserData for an item in a project I'm working on, so I added the API calls (`get_userdata_for_item` and `update_userdata_for_item`).

'Changes from Jellyfin Kodi' has been updated and tox tests all pass (apart from Python 3.8 which 'has been deprecated upstream' according to Homebrew).