### PR TITLE
Add TLS client authentication

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -758,7 +758,7 @@ class GranularAPIMixin:
 
         return request_method(url, **request_settings)
 
-    def login(self, server_url, username, password=""):
+    def login(self, server_url, username, password="", session=None):
         path = "Users/AuthenticateByName"
         authData = {
                     "username": username,
@@ -771,7 +771,7 @@ class GranularAPIMixin:
         try:
             LOG.info("Trying to login to %s/%s as %s" % (server_url, path, username))
             response = self.send_request(server_url, path, method="post", headers=headers,
-                                         data=json.dumps(authData), timeout=(5, 30))
+                                         data=json.dumps(authData), timeout=(5, 30), session=session)
 
             if response.status_code == 200:
                 return response.json()
@@ -786,23 +786,23 @@ class GranularAPIMixin:
 
         return {}
 
-    def validate_authentication_token(self, server):
+    def validate_authentication_token(self, server, session=None):
         headers = self.get_default_headers()
         comma = "," if "app.device_name" in self.config.data else ""
         headers["Authorization"] += f"{comma} Token=\"{server['AccessToken']}\""
 
-        response = self.send_request(server['address'], "system/info", headers=headers)
+        response = self.send_request(server['address'], "system/info", headers=headers, session=session)
         return response.json() if response.status_code == 200 else {}
 
-    def get_public_info(self, server_address):
-        response = self.send_request(server_address, "system/info/public")
+    def get_public_info(self, server_address, session=None):
+        response = self.send_request(server_address, "system/info/public", session=session)
         return response.json() if response.status_code == 200 else {}
 
-    def check_redirect(self, server_address):
+    def check_redirect(self, server_address, session=None):
         ''' Checks if the server is redirecting traffic to a new URL and
         returns the URL the server prefers to use
         '''
-        response = self.send_request(server_address, "system/info/public")
+        response = self.send_request(server_address, "system/info/public", session=session)
         url = response.url.replace('/system/info/public', '')
         return url
 

--- a/jellyfin_apiclient_python/connection_manager.py
+++ b/jellyfin_apiclient_python/connection_manager.py
@@ -8,6 +8,7 @@ import socket
 from datetime import datetime
 from operator import itemgetter
 
+import requests
 import urllib3
 
 from .credentials import Credentials
@@ -40,6 +41,16 @@ class ConnectionManager(object):
         self.config = client.config
         self.credentials = Credentials()
         self.API = API(HTTP(client))
+        
+        self.session = None
+
+    def create_session_with_client_auth(self):
+        if self.config.data['auth.tls_client_cert'] and self.config.data['auth.tls_client_key']:
+            self.session = requests.Session()
+            self.session.cert = (self.config.data['auth.tls_client_cert'], self.config.data['auth.tls_client_key'])
+            
+            if self.config.data['auth.tls_server_ca']:
+                self.session.verify = self.config.data['auth.tls_server_ca']
 
     def clear_data(self):
 
@@ -108,7 +119,7 @@ class ConnectionManager(object):
         if options is not None:
             LOG.warn("The options option on login() has no effect.")
 
-        data = self.API.login(server_url, username, password) # returns empty dict on failure
+        data = self.API.login(server_url, username, password, self.session) # returns empty dict on failure
 
         if not data:
             LOG.info("Failed to login as `"+username+"`")
@@ -153,7 +164,7 @@ class ConnectionManager(object):
         address = self._normalize_address(address)
 
         try:
-            response_url = self.API.check_redirect(address)
+            response_url = self.API.check_redirect(address, self.session)
             if address != response_url:
                 address = response_url
             LOG.info("connect_to_address %s succeeded", address)
@@ -176,7 +187,7 @@ class ConnectionManager(object):
         LOG.info("begin connect_to_server")
 
         try:
-            result = self.API.get_public_info(server.get('address'))
+            result = self.API.get_public_info(server.get('address'), self.session)
 
             if not result:
                 LOG.error("Failed to connect to server: %s" % server.get('address'))
@@ -335,7 +346,7 @@ class ConnectionManager(object):
             self.config.data['auth.token'] = server.pop('AccessToken', None)
 
         elif verify_authentication and server.get('AccessToken'):
-            system_info = self.API.validate_authentication_token(server)
+            system_info = self.API.validate_authentication_token(server, self.session)
             if system_info:
 
                 self._update_server_info(server, system_info)

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -29,10 +29,18 @@ class HTTP(object):
         self.config = client.config
 
     def start_session(self):
-
         self.session = requests.Session()
 
         max_retries = self.config.data['http.max_retries']
+        
+        # Configure the session for tls client authentication
+        if self.client.config.data['auth.tls_client_cert'] and self.client.config.data['auth.tls_client_key']:
+            self.session.cert = (self.client.config.data['auth.tls_client_cert'], 
+                                 self.client.config.data['auth.tls_client_key'])
+            
+            if self.client.config.data['auth.tls_server_ca']:
+                self.session.verify = self.client.config.data['auth.tls_server_ca']
+
         self.session.mount("http://", requests.adapters.HTTPAdapter(max_retries=max_retries))
         self.session.mount("https://", requests.adapters.HTTPAdapter(max_retries=max_retries))
 


### PR DESCRIPTION
This PR adds the mTLS / client certificate authentication to the API client. It is kinda basic and only allows to specify one set of files, which will be applied to all servers entered, but this made the modifications minimal. Don't know if there is any interest, mostly did it for myself.