### PR TITLE
Ability to set images for items and users. 

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -1081,6 +1081,29 @@ class ExperimentalAPIMixin:
                           data=data, headers=headers)
         return resp
 
+    def set_user_image(self, user_id, image_data):
+        """
+        Args:
+            item_id (str): user id to set the image for
+
+            image_data (str | PathLike | bytes | PIL.Image):
+                A path to an image on disk (PIL must be installed to read it),
+                or a base64 encoded image.
+
+        References:
+            .. [PostUserImage] https://api.jellyfin.org/#tag/Image/operation/PostUserImage
+        """
+        image_bytes, mimetype = self._coerce_image_bytes(image_data)
+        data = image_bytes.decode()
+        # Overriding headers are important for this call
+        headers = {
+            'Accept': '*/*',
+            'Content-type': mimetype,
+        }
+        resp = self._post("/UserImage", params={'user_id': user_id}, data=data,
+                          headers=headers)
+        return resp
+
 
 class CollectionAPIMixin:
     """

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -1046,26 +1046,32 @@ class ExperimentalAPIMixin:
 
         return image_bytes, mimetype
 
-    def set_item_image(self, item_id, image_data, image_type='Primary'):
+    def set_item_image(self, item_id, image_data, image_type='Primary',
+                       mimetype='auto'):
         """
         Args:
             item_id (str): item to set the image of
 
-            image_data (str | PathLike | bytes | PIL.Image):
-                A path to an image on disk (PIL must be installed to read it),
-                or a base64 encoded image.
+            image_data (str | PathLike | bytes):
+                A path to an image on disk or raw bytes of an image.
 
             image_type (str): A valid image type. I.e. one of
                 'Primary', 'Art', 'Backdrop', 'Banner', 'Logo', 'Thumb',
                 'Disc', 'Box', 'Screenshot', 'Menu', 'Chapter', 'BoxRear',
                 'Profile'.
 
+            mimetype (str): if "auto", attempt to infer the mimetype.
+                falls back to image/jpeg if unable. Otherwise this is used.
+
         References:
             .. [SetItemImageByIndex] https://api.jellyfin.org/#tag/Image/operation/SetItemImageByIndex
         """
         from jellyfin_apiclient_python.constants import ImageType
 
-        image_bytes, mimetype = self._coerce_image_bytes(image_data)
+        image_bytes, auto_mimetype = self._coerce_image_bytes(image_data)
+
+        if mimetype == 'auto':
+            mimetype = auto_mimetype
 
         if image_type not in ImageType:
             raise KeyError(f'image_type must be one of: {ImageType}')
@@ -1081,19 +1087,25 @@ class ExperimentalAPIMixin:
                           data=data, headers=headers)
         return resp
 
-    def set_user_image(self, user_id, image_data):
+    def set_user_image(self, user_id, image_data, mimetype='auto'):
         """
         Args:
             item_id (str): user id to set the image for
 
-            image_data (str | PathLike | bytes | PIL.Image):
-                A path to an image on disk (PIL must be installed to read it),
-                or a base64 encoded image.
+            image_data (str | PathLike | bytes):
+                A path to an image on disk or raw bytes of an image.
+
+            mimetype (str): if "auto", attempt to infer the mimetype.
+                falls back to image/jpeg if unable. Otherwise this is used.
 
         References:
             .. [PostUserImage] https://api.jellyfin.org/#tag/Image/operation/PostUserImage
         """
-        image_bytes, mimetype = self._coerce_image_bytes(image_data)
+        image_bytes, auto_mimetype = self._coerce_image_bytes(image_data)
+
+        if mimetype == 'auto':
+            mimetype = auto_mimetype
+
         data = image_bytes.decode()
         # Overriding headers are important for this call
         headers = {

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -67,8 +67,9 @@ class InternalAPIMixin:
     def _get_url(self, handler, params=None):
         return self._http_url("GET", handler, {"params": params})
 
-    def _post(self, handler, json=None, params=None):
-        return self._http("POST", handler, {'params': params, 'json': json})
+    def _post(self, handler, json=None, params=None, data=None, headers=None):
+        return self._http("POST", handler, {'params': params, 'json': json,
+                                            'data': data, 'headers': headers})
 
     def _delete(self, handler, params=None):
         return self._http("DELETE", handler, {'params': params})
@@ -172,9 +173,9 @@ class BiggerAPIMixin:
         }
         return self.virtual_folders('POST', params=params)
 
-    def items(self, handler="", action="GET", params=None, json=None):
+    def items(self, handler="", action="GET", params=None, json=None, data=None, headers=None):
         if action == "POST":
-            return self._post("Items%s" % handler, json, params)
+            return self._post("Items%s" % handler, json, params, data, headers)
         elif action == "DELETE":
             return self._delete("Items%s" % handler, params)
         else:

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -207,7 +207,11 @@ class HTTP(object):
         if 'url' not in data:
             data['url'] = "%s/%s" % (self.config.data.get("auth.server", ""), data.pop('handler', ""))
 
-        data['headers'] = self._get_default_headers() | (data.get('headers', None) or {})
+        headers = self._get_default_headers()
+        user_specified_headers = (data.get('headers', None) or {})
+        headers.update(user_specified_headers)
+
+        data['headers'] = headers
         data['timeout'] = data.get('timeout') or self.config.data['http.timeout']
         data['verify'] = data.get('verify') or self.config.data.get('auth.ssl', False)
         data['url'] = self._replace_user_info(data['url'])

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -207,7 +207,7 @@ class HTTP(object):
         if 'url' not in data:
             data['url'] = "%s/%s" % (self.config.data.get("auth.server", ""), data.pop('handler', ""))
 
-        data['headers'] = self._get_default_headers()
+        data['headers'] = self._get_default_headers() | (data.get('headers', None) or {})
         data['timeout'] = data.get('timeout') or self.config.data['http.timeout']
         data['verify'] = data.get('verify') or self.config.data.get('auth.ssl', False)
         data['url'] = self._replace_user_info(data['url'])
@@ -217,6 +217,9 @@ class HTTP(object):
         return data
 
     def _process_params(self, params):
+        if isinstance(params, str):
+            # Json is being used as data
+            return
 
         for key in params:
             value = params[key]


### PR DESCRIPTION
This PR adds the ability to set the image for an item. The new function accepts either a path to an image, or raw image bytes.

In order to get the corresponding POST request to work I had to modify two internals:

* Allow POST calls to specify the "data" argument to `session.post`
* Allow POST calls to modify the default header data

The problem is that the API call for [SetItemImageByIndex](https://api.jellyfin.org/#tag/Image/operation/SetItemImageByIndex) and [PostUserImage](https://api.jellyfin.org/#tag/Image/operation/PostUserImage) do not take key/value json data as input, instead they take base64 encoded images. They also need to specify the Content-Type header as the mime type of the data.

On the Python side, I added two new public methods, and an internal method to help coerce user-specified data into the appropriate image encoding.

I've also added a new constants.py file (with python 3.6 compatible StrEnum) to store valid values for various JellyfinAPI parameter types. 

