### PR TITLE
Feat/more collection methods

### DIFF
--- a/jellyfin_apiclient_python/constants.py
+++ b/jellyfin_apiclient_python/constants.py
@@ -1,0 +1,75 @@
+from enum import Enum
+
+# from enum import StrEnum
+
+
+class StrEnum(str, Enum):
+    """
+    Minimal string enum that works with Python 3.6+
+    """
+    def __str__(self):
+        return self.value
+
+    @classmethod
+    def _missing_(cls, value):
+        # Allow case-insensitive lookups
+        for member in cls:
+            if member.value.lower() == value.lower():
+                return member
+        return None
+
+
+class ItemType(StrEnum):
+    AGGREGATE_FOLDER = "AggregateFolder"
+    AUDIO = "Audio"
+    AUDIO_BOOK = "AudioBook"
+    BASE_PLUGIN_FOLDER = "BasePluginFolder"
+    BOOK = "Book"
+    BOX_SET = "BoxSet"
+    CHANNEL = "Channel"
+    CHANNEL_FOLDER_ITEM = "ChannelFolderItem"
+    COLLECTION_FOLDER = "CollectionFolder"
+    EPISODE = "Episode"
+    FOLDER = "Folder"
+    GENRE = "Genre"
+    MANUAL_PLAYLISTS_FOLDER = "ManualPlaylistsFolder"
+    MOVIE = "Movie"
+    LIVE_TV_CHANNEL = "LiveTvChannel"
+    LIVE_TV_PROGRAM = "LiveTvProgram"
+    MUSIC_ALBUM = "MusicAlbum"
+    MUSIC_ARTIST = "MusicArtist"
+    MUSIC_GENRE = "MusicGenre"
+    MUSIC_VIDEO = "MusicVideo"
+    PERSON = "Person"
+    PHOTO = "Photo"
+    PHOTO_ALBUM = "PhotoAlbum"
+    PLAYLIST = "Playlist"
+    PLAYLISTS_FOLDER = "PlaylistsFolder"
+    PROGRAM = "Program"
+    RECORDING = "Recording"
+    SEASON = "Season"
+    SERIES = "Series"
+    STUDIO = "Studio"
+    TRAILER = "Trailer"
+    TV_CHANNEL = "TvChannel"
+    TV_PROGRAM = "TvProgram"
+    USER_ROOT_FOLDER = "UserRootFolder"
+    USER_VIEW = "UserView"
+    VIDEO = "Video"
+    YEAR = "Year"
+
+
+class ImageType(StrEnum):
+    PRIMARY = "Primary"
+    ART = "Art"
+    BACKDROP = "Backdrop"
+    BANNER = "Banner"
+    LOGO = "Logo"
+    THUMB = "Thumb"
+    DISC = "Disc"
+    BOX = "Box"
+    SCREENSHOT = "Screenshot"
+    MENU = "Menu"
+    CHAPTER = "Chapter"
+    BOXREAR = "BoxRear"
+    PROFILE = "Profile"


### PR DESCRIPTION
This PR adds 3 new API methods. `get_collection_folders`, `get_collections`, and `delete_collection`. For the two get functions, I didn't do any work to support pagination, but there are several functions like this, so I figure someone will add it if it is needed. The number of collections I have is fairly small, so I don't have a lot of motivation to take on the extra complexity.

I noticed some peculiarities when I was working on this. I commented on them in the [jellyfin dev chat](https://matrix.to/#/#jellyfin-dev:matrix.org/$14VsLR-fLWPmrJeQIfApmQNWt9eTRRXOiI3-KRVPjmY).

Long story short, it seems user-created collections have a type "BoxSet", and the higher level auto-created collections have a type "CollectionFolder". Because the UI shows BoxSets as collections, I figured I would just use that term in the API. That could be changed.

For the higher level collection-folders, those have some weird query properties. They only show up if you set recurse=False, and you can't filter them, even though the API docs would suggest you could. 

This PR shares one commit with https://github.com/jellyfin/jellyfin-apiclient-python/pull/58 where I add a Python module to track the type names expected by the jellyfin API.

Side Note: I also found a funny server bug. If you run `client.jellyfin.new_collection('My Collection #1')`, for whatever reason the new collection that is created is named "My Super Psycho Sweet 16 Collection" :rofl: .  It turns out the code path where you make a collection without any items is not available in the UI, so its likely untested.