### PR TITLE
Fix the identify() experimental mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The test suite is run via `tox`, and you can install it from PyPi.
  - Add support for authenticating via an API key
  - Add support for the optional 'date played' parameter in the `item_played` API method
  - Add API calls `get_userdata_for_item` and `update_userdata_for_item`
+ - Fix the experimental `identify` method so it works with the API structure
 
 ## Contributing
 

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -965,7 +965,7 @@ class ExperimentalAPIMixin:
     This is a location for testing proposed additions to the API Client.
     """
 
-    def identify(client, item_id, provider_ids):
+    def identify(self, item_id, provider_ids):
         """
         Remote search for item metadata given one or more provider id.
 
@@ -984,7 +984,9 @@ class ExperimentalAPIMixin:
             .. [RemoveProviderSearch] https://api.jellyfin.org/#tag/ItemLookup/operation/ApplySearchCriteria
         """
         body = {'ProviderIds': provider_ids}
-        return client.jellyfin.items('/RemoteSearch/Apply/' + item_id, action='POST', params=None, json=body)
+        return self.items(
+            "/RemoteSearch/Apply/" + item_id, action="POST", params=None, json=body
+        )
 
     def get_now_playing(self, session_id):
         """


### PR DESCRIPTION
The experimental identify() mixin uses a defunct 'client.jellyfin' identifier when it should just use 'self'.

Using tox: all tests pass except for Python 3.8 which is automatically skipped.