### PR TITLE
Update experimental identify API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The test suite is run via `tox`, and you can install it from PyPi.
  - Add support for authenticating via an API key
  - Add support for the optional 'date played' parameter in the `item_played` API method
  - Add API calls `get_userdata_for_item` and `update_userdata_for_item`
+ - Extend the (currently) experimental `identify` API call to include all parameters supported by Jellyfin
 
 ## Contributing
 

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -966,26 +966,44 @@ class ExperimentalAPIMixin:
     This is a location for testing proposed additions to the API Client.
     """
 
-    def identify(client, item_id, provider_ids):
+    def identify(self, item_id, name=None, provider_ids=None, year=None, replaceAllImages=True):
         """
-        Remote search for item metadata given one or more provider id.
+        Applies search criteria to an item and refreshes metadata.
 
         This method requires an authenticated user with elevated permissions
-        [RemoveProviderSearch]_.
+        [RequiresElevation]_.
 
         Args:
             item_id (str): item uuid to identify and update metadata for.
 
-            provider_ids (Dict):
+            name (str):
+                name for the identified item
+            provider_ids (dict):
                 maps providers to the content id. (E.g. {"Imdb": "tt1254207"})
                 Valid keys will depend on available providers. Common ones are:
                     "Tvdb" and "Imdb".
+            year (int):
+                production year for the identified idem
+            replaceAllImages(bool):
+                whether all images should be replaced by default
 
         References:
-            .. [RemoveProviderSearch] https://api.jellyfin.org/#tag/ItemLookup/operation/ApplySearchCriteria
+            .. [ApplySearchCriteria] https://api.jellyfin.org/#tag/ItemLookup/operation/ApplySearchCriteria
         """
-        body = {'ProviderIds': provider_ids}
-        return client.jellyfin.items('/RemoteSearch/Apply/' + item_id, action='POST', params=None, json=body)
+
+        data = {
+            'Name': name, 
+            'ProviderIds': provider_ids, 
+            'ProductionYear': year
+        }
+        params = {
+            'replaceAllImages': replaceAllImages
+        }
+
+        return self._post(
+            f'Items/RemoteSearch/Apply/{item_id}', params=params, json=data
+        )
+
 
     def get_now_playing(self, session_id):
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
-from jellyfin_apiclient_python.api import jellyfin_url
-from unittest.mock import Mock
+from jellyfin_apiclient_python.api import jellyfin_url, API
+from jellyfin_apiclient_python.http import HTTP
+from unittest.mock import Mock, patch
+from unittest import TestCase
 
 def test_jellyfin_url_handles_trailing_slash():
     mock_client = Mock()
@@ -11,3 +13,65 @@ def test_jellyfin_url_handles_trailing_slash():
     mock_client.config.data = {'auth.server': 'https://example.com'}
     url = jellyfin_url(mock_client, handler)
     assert url == "https://example.com/Items/1234"
+
+
+class TestIdentify(TestCase):
+    def setup_requests(self):
+        patcher = patch('jellyfin_apiclient_python.http.HTTP.request')
+        self.addCleanup(patcher.stop)
+        self.mock_request = patcher.start()
+
+    def setup_api(self):
+        mock_client = Mock()
+        self.api = API(HTTP(mock_client))
+
+    def setup_data(self):
+        self.defaultParams = {'replaceAllImages': True}
+        self.defaultJson = {'Name': None, 'ProviderIds': None, 'ProductionYear': None}
+        self.handler = 'Items/RemoteSearch/Apply'
+
+    def setUp(self):
+        self.setup_requests()
+        self.setup_api()
+        self.setup_data()
+
+    def build_handler_for_item_id(self, item_id) -> str:
+        return f"{self.handler}/{item_id}"
+
+    def assert_request_matches_call_parameters(self, item_id, params, json) -> None:
+        parameters = self.mock_request.call_args.args[0]
+        assert(parameters['params'] == params)
+        assert(parameters['json'] == json)
+        assert(parameters['handler'] == self.build_handler_for_item_id(item_id))
+
+    def test_defaults_are_as_expected(self):
+        item_id = 1234
+
+        self.api.identify(item_id=item_id)
+
+        self.mock_request.assert_called_once()
+        self.assert_request_matches_call_parameters(item_id, self.defaultParams, self.defaultJson)
+
+    def do_image_replacement(self, item_id, replace):
+        self.api.identify(item_id=item_id, replaceAllImages=replace)
+
+        self.mock_request.assert_called_once()
+        self.assert_request_matches_call_parameters(item_id, {'replaceAllImages': replace}, self.defaultJson)
+
+    def test_images_are_replaced(self):
+        self.do_image_replacement(1235, True)
+
+    def test_images_are_not_replaced(self):
+        self.do_image_replacement(1236, False)
+
+    def test_parameters_are_propagated(self):
+        item_id = 1237
+        name = 'foo'
+        ids = {'id1': 1, 'id2': 2}
+        year = 1964
+        json = {'Name': name, 'ProviderIds': ids, 'ProductionYear': year}
+
+        self.api.identify(item_id=item_id, name=name, provider_ids=ids, year=year)
+
+        self.mock_request.assert_called_once()
+        self.assert_request_matches_call_parameters(item_id, self.defaultParams, json)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py{38,39,310,311,312},
+    py{38,39,310,311,312,313},
 
 [gh-actions]
 python =
@@ -10,6 +10,7 @@ python =
     3.10: py310, lint
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 deps =


### PR DESCRIPTION
Resolves #66 by adding all supported parameters to the (currently) experimental `identify()` API call.

Unit tests have been added and `README.md` updated accordingly.

The tox test environments have been extended to include Python 3.13.

`tox` passes lint and all test environments successfully other than Python 3.8, which is skipped by tox itself.