### PR TITLE
Fixed Info and Configuration missmatch

### DIFF
--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -601,6 +601,11 @@ class GranularAPIMixin:
         return self.users("/FavoriteItems/%s" % item_id, "POST" if option else "DELETE")
 
     def get_system_info(self):
+        """Returns configuration for legacy reasons, not System/Info, use get_system_info_new for that""
+        return self._get("System/Configuration")
+
+    def get_system_info_new(self):
+        """Actual System/Info API call""
         return self._get("System/Info")
 
     def get_system_configuration(self):

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -601,6 +601,9 @@ class GranularAPIMixin:
         return self.users("/FavoriteItems/%s" % item_id, "POST" if option else "DELETE")
 
     def get_system_info(self):
+        return self._get("System/Info")
+
+    def get_system_configuration(self):
         return self._get("System/Configuration")
 
     def get_server_logs(self):


### PR DESCRIPTION
From API:

https://api.jellyfin.org/#tag/Configuration
https://api.jellyfin.org/#tag/System/operation/GetSystemInfo

w/o this fix for instance is not possible to get the server version.

For patch this problem for who find this:

```python
from jellyfin_apiclient_python import JellyfinClient
from jellyfin_apiclient_python.api import API

class JellyfinAPI(API):
    def __init__(self, client, *args, **kwargs):
        super().__init__(client, *args, **kwargs)

    def get_system_info(self):
        """Override to get system info"""
        return self._get("System/Info")
```