### PR TITLE
Fixed missing exception when user id is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,15 @@ You can also authenticate using an API key, which is generated on the server.
 This is different to a device AccessToken, and is set by not configuring a
 device name, or a device id:
 
-```
+```python
 client.config.data["app.name"] = 'your_brilliant_app'
 client.config.data["app.version"] = '0.0.1'
-client.authenticate({"Servers": [{"AccessToken": <API key here>, "address": <Server Address>}]}, discover=False)
+client.authenticate({"Servers": [{"AccessToken": '<API key here>', "address": '<Server Address>'}]}, discover=False)
+
+# Some endpoint require a user context event using API Key.
+
+client.config.data["auth.user_id"] = '<UserID here>'
+client.authenticate({"Servers": [{"AccessToken": '<API key here>', "address": '<Server Address>'}]}, discover=False)
 ```
 
 ### API
@@ -63,9 +68,8 @@ are a dictionary with 3 members, "Items", "TotalRecordCount" and "StartIndex"
 The easiest way to fetch media objects is by calling `search_media_items`, like
 so:
 
-```
-client.jellyfin.search_media_items(
-    term="And Now for Something Completely Different", media="Videos")
+```python
+client.jellyfin.search_media_items(term="And Now for Something Completely Different", media="Videos")
 ```
 
 For details on what the individual API calls do or how to do a certain task, you will probably find the [Jellyfin MPV Shim](https://github.com/iwalton3/jellyfin-mpv-shim) and [Jellyfin Kodi](https://github.com/jellyfin/jellyfin-kodi) repositories useful.

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -61,18 +61,21 @@ class HTTP(object):
             if self.config.data.get('auth.server', None):
                 string = string.replace("{server}", self.config.data['auth.server'])
             else:
+                LOG.debug("Server address not set")
                 raise ValueError("Server is not set.")
 
         if '{UserId}'in string:
             if self.config.data.get('auth.user_id', None):
                 string = string.replace("{UserId}", self.config.data['auth.user_id'])
             else:
+                 LOG.debug("UserId is not set.")
                 raise ValueError("UserId is not set. If using API_KEY, some endpoint require a user context.")
 
         if '{DeviceId}'in string:
             if self.config.data.get('app.device_id', None):
                 string = string.replace("{DeviceId}", self.config.data['app.device_id'])
             else:
+                LOG.debug("DeviceId is not set.")
                 raise ValueError("DeviceId is not set.")
 
         return string

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -61,19 +61,19 @@ class HTTP(object):
             if self.config.data.get('auth.server', None):
                 string = string.replace("{server}", self.config.data['auth.server'])
             else:
-                LOG.debug("Server address not set")
+                raise ValueError("Server is not set.")
 
         if '{UserId}'in string:
             if self.config.data.get('auth.user_id', None):
                 string = string.replace("{UserId}", self.config.data['auth.user_id'])
             else:
-                LOG.debug("UserId is not set.")
+                raise ValueError("UserId is not set. If using API_KEY, some endpoint require a user context.")
 
         if '{DeviceId}'in string:
             if self.config.data.get('app.device_id', None):
                 string = string.replace("{DeviceId}", self.config.data['app.device_id'])
             else:
-                LOG.debug("DeviceId is not set.")
+                raise ValueError("DeviceId is not set.")
 
         return string
 

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -68,7 +68,7 @@ class HTTP(object):
             if self.config.data.get('auth.user_id', None):
                 string = string.replace("{UserId}", self.config.data['auth.user_id'])
             else:
-                 LOG.debug("UserId is not set.")
+                LOG.debug("UserId is not set.")
                 raise ValueError("UserId is not set. If using API_KEY, some endpoint require a user context.")
 
         if '{DeviceId}'in string:


### PR DESCRIPTION
When `UserId`, `server` and `DeviceId` is missing during the replace or the url from endpoint a exception need to be raise because even w/o will fail.

Some directions and minor improvments are added to readme.

Fixes #61

PS: Will be better to support user_name on configuration