### PR TITLE
Refactor so core http tasks are async

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,61 @@ client.jellyfin.search_media_items(
     term="And Now for Something Completely Different", media="Videos")
 ```
 
+### Async usage
+
+The synchronous API remains unchanged. You can access the async API via
+`client.aio`, which exposes async versions of the same Jellyfin API calls:
+
+```
+import asyncio
+from jellyfin_apiclient_python import JellyfinClient
+
+client = JellyfinClient()
+client.config.app('your_brilliant_app', '0.0.1', 'machine_name', 'unique_id')
+client.config.data["auth.ssl"] = True
+
+# Authenticate synchronously, then switch to async API for calls.
+client.auth.connect_to_address('server_url')
+client.auth.login('server_url', 'username', 'password')
+
+async def main():
+    system_info = await client.aio.jellyfin.get_system_info()
+    print(system_info)
+
+asyncio.run(main())
+client.close()
+```
+
+You can also use `AsyncJellyfinClient` directly if you already have a token:
+
+```
+import asyncio
+from jellyfin_apiclient_python import AsyncJellyfinClient
+
+async def main():
+    client = AsyncJellyfinClient()
+    client.config.data["auth.server"] = "https://example.com"
+    client.config.data["auth.token"] = "your_token"
+    async with client:
+        system_info = await client.jellyfin.get_system_info()
+        print(system_info)
+
+asyncio.run(main())
+```
+
+### Closing clients
+
+Use `client.close()` for sync clients and `await client.aclose()` for async
+clients. Both classes support context management:
+
+```
+with JellyfinClient() as client:
+    ...
+
+async with AsyncJellyfinClient() as client:
+    ...
+```
+
 For details on what the individual API calls do or how to do a certain task, you will probably find the [Jellyfin MPV Shim](https://github.com/iwalton3/jellyfin-mpv-shim) and [Jellyfin Kodi](https://github.com/jellyfin/jellyfin-kodi) repositories useful.
 
 ## Running the tests

--- a/jellyfin_apiclient_python/__init__.py
+++ b/jellyfin_apiclient_python/__init__.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from .client import JellyfinClient
+from .client import JellyfinClient, AsyncJellyfinClient
 
 #################################################################################################
 
@@ -88,7 +88,7 @@ class Jellyfin(object):
         if self.server_id not in self.client:
             return
 
-        self.client[self.server_id].stop()
+        self.client[self.server_id].close()
         self.client.pop(self.server_id, None)
 
         LOG.info("---[ STOPPED JELLYFINCLIENT: %s ]---", self.server_id)
@@ -97,7 +97,7 @@ class Jellyfin(object):
     def close_all(cls):
 
         for client in cls.client:
-            cls.client[client].stop()
+            cls.client[client].close()
 
         cls.client = {}
         LOG.info("---[ STOPPED ALL JELLYFINCLIENTS ]---")

--- a/jellyfin_apiclient_python/__init__.py
+++ b/jellyfin_apiclient_python/__init__.py
@@ -10,6 +10,11 @@ from .client import JellyfinClient, AsyncJellyfinClient
 
 __version__ = '1.11.0'
 
+__all__ = [
+    "AsyncJellyfinClient",
+    "JellyfinClient",
+]
+
 
 class NullHandler(logging.Handler):
     def emit(self, record):

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -59,7 +59,7 @@ class InternalAPIMixin:
     def _http_stream(self, action, url, dest_file, request={}):
         request.update({'type': action, 'handler': url})
 
-        self.client.request(request, dest_file=dest_file)
+        return self.client.request(request, dest_file=dest_file)
 
     def _get(self, handler, params=None):
         return self._http("GET", handler, {'params': params})
@@ -75,7 +75,7 @@ class InternalAPIMixin:
         return self._http("DELETE", handler, {'params': params})
 
     def _get_stream(self, handler, dest_file, params=None):
-        self._http_stream("GET", handler, dest_file, {'params': params})
+        return self._http_stream("GET", handler, dest_file, {'params': params})
 
 
 class BiggerAPIMixin:

--- a/jellyfin_apiclient_python/async_api.py
+++ b/jellyfin_apiclient_python/async_api.py
@@ -18,6 +18,9 @@ class AsyncAPI:
     Methods are exposed as async callables and route to AsyncHTTP.request,
     while a small subset of request helpers are reimplemented to avoid
     blocking on synchronous requests.
+
+    Future work should investigate making this async version the primary
+    implementation and have the sync API be the wrapper.
     """
 
     def __init__(self, http):
@@ -128,6 +131,9 @@ class AsyncAPI:
         return self._api.get_default_headers()
 
     def __getattr__(self, name):
+        """
+        Forward the requests to the sync API
+        """
         attr = getattr(self._api, name)
         if callable(attr):
             async def wrapper(*args, **kwargs):

--- a/jellyfin_apiclient_python/async_api.py
+++ b/jellyfin_apiclient_python/async_api.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+import json
+import logging
+
+from .httpx_compat import httpx
+
+from .api import API
+
+LOG = logging.getLogger('JELLYFIN.' + __name__)
+
+
+class AsyncAPI:
+    """
+    Async wrapper around the existing API mixins.
+
+    Methods are exposed as async callables and route to AsyncHTTP.request,
+    while a small subset of request helpers are reimplemented to avoid
+    blocking on synchronous requests.
+    """
+
+    def __init__(self, http):
+        self._api = API(http)
+        self.client = self._api.client
+        self.config = self._api.config
+        self.default_timeout = self._api.default_timeout
+
+    def _client_kwargs(self):
+        cert = None
+        verify = self.config.data.get('auth.ssl', False)
+        if 'auth.tls_client_cert' in self.config.data and 'auth.tls_client_key' in self.config.data:
+            cert = (
+                self.config.data['auth.tls_client_cert'],
+                self.config.data['auth.tls_client_key'],
+            )
+            if self.config.data['auth.tls_server_ca']:
+                verify = self.config.data['auth.tls_server_ca']
+        return {
+            "verify": verify,
+            "cert": cert,
+        }
+
+    async def send_request(self, server_url, path, method="get", headers=None,
+                           data=None, timeout=None, session=None):
+        headers = headers or self.get_default_headers()
+        request_settings = {
+            'headers': headers,
+            'timeout': timeout or self.default_timeout,
+        }
+        if data is not None:
+            request_settings['data'] = data
+
+        url = "%s/%s" % (server_url.rstrip('/'), path.lstrip('/'))
+
+        if self.config.data.get('auth.ssl') is False:
+            request_settings["verify"] = False
+
+        LOG.info("Sending %s request to %s", method, path)
+        LOG.debug(request_settings['timeout'])
+        LOG.debug(request_settings['headers'])
+
+        if session is not None:
+            request_method = getattr(session, method.lower())
+            return await request_method(url, **request_settings)
+
+        async with httpx.AsyncClient(**self._client_kwargs()) as client:
+            request_method = getattr(client, method.lower())
+            return await request_method(url, **request_settings)
+
+    async def login(self, server_url, username, password="", session=None):
+        path = "Users/AuthenticateByName"
+        auth_data = {
+            "username": username,
+            "Pw": password
+        }
+
+        headers = self.get_default_headers()
+        headers.update({'Content-type': "application/json"})
+
+        try:
+            LOG.info("Trying to login to %s/%s as %s", server_url, path, username)
+            response = await self.send_request(
+                server_url,
+                path,
+                method="post",
+                headers=headers,
+                data=json.dumps(auth_data),
+                timeout=(5, 30),
+                session=session,
+            )
+
+            if response.status_code == 200:
+                return response.json()
+            LOG.error("Failed to login to server with status code: %s", response.status_code)
+            LOG.error("Server Response:\n%s", response.content)
+            LOG.debug(headers)
+
+            return {}
+        except Exception as error:
+            LOG.error(error)
+
+        return {}
+
+    async def validate_authentication_token(self, server, session=None):
+        headers = self.get_default_headers()
+        comma = "," if "app.device_name" in self.config.data else ""
+        headers["Authorization"] += f"{comma} Token=\"{server['AccessToken']}\""
+
+        response = await self.send_request(
+            server['address'],
+            "system/info",
+            headers=headers,
+            session=session,
+        )
+        return response.json() if response.status_code == 200 else {}
+
+    async def get_public_info(self, server_address, session=None):
+        response = await self.send_request(server_address, "system/info/public", session=session)
+        return response.json() if response.status_code == 200 else {}
+
+    async def check_redirect(self, server_address, session=None):
+        response = await self.send_request(server_address, "system/info/public", session=session)
+        url = response.url.replace('/system/info/public', '')
+        return url
+
+    def get_default_headers(self):
+        return self._api.get_default_headers()
+
+    def __getattr__(self, name):
+        attr = getattr(self._api, name)
+        if callable(attr):
+            async def wrapper(*args, **kwargs):
+                result = attr(*args, **kwargs)
+                if asyncio.iscoroutine(result):
+                    return await result
+                return result
+
+            return wrapper
+        return attr

--- a/jellyfin_apiclient_python/async_http.py
+++ b/jellyfin_apiclient_python/async_http.py
@@ -103,6 +103,10 @@ class AsyncHTTP:
         retry = data.pop('retry', 5)
         stream = dest_file is not None
 
+        server_id = None
+        if 'auth.server-id' in self.config.data:
+            server_id = self.config.data['auth.server-id']
+
         while True:
             try:
                 method = data.pop('type', "GET")
@@ -129,7 +133,8 @@ class AsyncHTTP:
                     continue
 
                 LOG.error(error)
-                self.client.callback("ServerUnreachable", {'ServerId': self.config.data['auth.server-id']})
+                if server_id is not None:
+                    self.client.callback("ServerUnreachable", {'ServerId': server_id})
 
                 raise HTTPException("ServerUnreachable", error)
 
@@ -148,10 +153,12 @@ class AsyncHTTP:
 
                 if status_code == 401:
                     if 'X-Application-Error-Code' in error.response.headers:
-                        self.client.callback("AccessRestricted", {'ServerId': self.config.data['auth.server-id']})
+                        if server_id is not None:
+                            self.client.callback("AccessRestricted", {'ServerId': server_id})
                         raise HTTPException("AccessRestricted", error)
 
-                    self.client.callback("Unauthorized", {'ServerId': self.config.data['auth.server-id']})
+                    if server_id is not None:
+                        self.client.callback("Unauthorized", {'ServerId': server_id})
                     if hasattr(self.client, "auth"):
                         self.client.auth.revoke_token()
                     raise HTTPException("Unauthorized", error)

--- a/jellyfin_apiclient_python/async_http.py
+++ b/jellyfin_apiclient_python/async_http.py
@@ -197,6 +197,7 @@ class AsyncHTTP:
         return await self._requests(active_session, action, stream=stream, **kwargs)
 
     async def _requests(self, session, action, stream=False, **kwargs):
+        kwargs.pop("verify", None)
         if stream:
             kwargs["stream"] = True
         if action == "GET":

--- a/jellyfin_apiclient_python/async_http.py
+++ b/jellyfin_apiclient_python/async_http.py
@@ -67,13 +67,13 @@ class AsyncHTTP:
             else:
                 LOG.debug("Server address not set")
 
-        if '{UserId}'in string:
+        if '{UserId}' in string:
             if self.config.data.get('auth.user_id', None):
                 string = string.replace("{UserId}", self.config.data['auth.user_id'])
             else:
                 LOG.debug("UserId is not set.")
 
-        if '{DeviceId}'in string:
+        if '{DeviceId}' in string:
             if self.config.data.get('app.device_id', None):
                 string = string.replace("{DeviceId}", self.config.data['app.device_id'])
             else:
@@ -95,6 +95,16 @@ class AsyncHTTP:
         return "%s?%s" % (data["url"], encoded_params)
 
     async def request(self, data, session=None, dest_file=None):
+        ''' Give a chance to retry the connection. Jellyfin sometimes can be slow to answer back
+            data dictionary can contain:
+            type: GET, POST, etc.
+            url: (optional)
+            handler: not considered when url is provided (optional)
+            params: request parameters (optional)
+            json: request body (optional)
+            headers: (optional),
+            verify: ssl certificate, True (verify using device built-in library) or False
+        '''
         if not data:
             raise AttributeError("Request cannot be empty")
 
@@ -114,10 +124,10 @@ class AsyncHTTP:
                 try:
                     if stream:
                         async for chunk in response.aiter_bytes(chunk_size=8192):
-                            if chunk:
+                            if chunk:   # filter out keep-alive new chunks
                                 dest_file.write(chunk)
                     else:
-                        await response.aread()
+                        await response.aread()  # release the connection
 
                     if not self.keep_alive and self.session is not None:
                         await self.stop_session()
@@ -243,6 +253,7 @@ class AsyncHTTP:
 
     def _process_params(self, params):
         if isinstance(params, str):
+            # Json is being used as data
             return
 
         for key in params:

--- a/jellyfin_apiclient_python/async_http.py
+++ b/jellyfin_apiclient_python/async_http.py
@@ -211,7 +211,10 @@ class AsyncHTTP:
     async def _requests(self, session, action, stream=False, **kwargs):
         kwargs.pop("verify", None)
         if stream:
-            kwargs["stream"] = True
+            try:
+                return await session.request(action, **kwargs, stream=True)
+            except TypeError:
+                return await session.request(action, **kwargs)
         if action == "GET":
             return await session.get(**kwargs)
         if action == "POST":

--- a/jellyfin_apiclient_python/async_http.py
+++ b/jellyfin_apiclient_python/async_http.py
@@ -187,9 +187,14 @@ class AsyncHTTP:
                     if stream:
                         return
                     self.config.data['server-time'] = response.headers['Date']
-                    elapsed = int(response.elapsed.total_seconds() * 1000)
+                    elapsed_ms = None
+                    if hasattr(response, "_elapsed"):
+                        elapsed_ms = int(response.elapsed.total_seconds() * 1000)
                     response_json = response.json()
-                    LOG.debug("---<[ http ][%s ms]", elapsed)
+                    if elapsed_ms is not None:
+                        LOG.debug("---<[ http ][%s ms]", elapsed_ms)
+                    else:
+                        LOG.debug("---<[ http ]")
                     LOG.debug(json.dumps(response_json, indent=4))
 
                     return response_json

--- a/jellyfin_apiclient_python/async_http.py
+++ b/jellyfin_apiclient_python/async_http.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+
+import asyncio
+import json
+import logging
+import urllib
+
+from .httpx_compat import httpx
+
+from .exceptions import HTTPException
+
+#################################################################################################
+
+LOG = logging.getLogger('Jellyfin.' + __name__)
+
+#################################################################################################
+
+
+class AsyncHTTP:
+
+    session = None
+    keep_alive = False
+
+    def __init__(self, client):
+        self.client = client
+        self.config = client.config
+
+    async def start_session(self):
+        self.session = self._create_client()
+
+    async def stop_session(self):
+        if self.session is None:
+            return
+        try:
+            LOG.info("--<[ session/%s ]", id(self.session))
+            await self.session.aclose()
+        except Exception as error:
+            LOG.warning("The async HTTP session could not be terminated: %s", error)
+        finally:
+            self.session = None
+
+    def _client_kwargs(self):
+        cert = None
+        verify = self.config.data.get('auth.ssl', False)
+        if 'auth.tls_client_cert' in self.client.config.data and 'auth.tls_client_key' in self.client.config.data:
+            cert = (
+                self.client.config.data['auth.tls_client_cert'],
+                self.client.config.data['auth.tls_client_key'],
+            )
+            if self.client.config.data['auth.tls_server_ca']:
+                verify = self.client.config.data['auth.tls_server_ca']
+        return {
+            "timeout": self.config.data['http.timeout'],
+            "verify": verify,
+            "cert": cert,
+        }
+
+    def _create_client(self):
+        return httpx.AsyncClient(**self._client_kwargs())
+
+    def _replace_user_info(self, string):
+        if '{server}' in string:
+            if self.config.data.get('auth.server', None):
+                string = string.replace("{server}", self.config.data['auth.server'])
+            else:
+                LOG.debug("Server address not set")
+
+        if '{UserId}'in string:
+            if self.config.data.get('auth.user_id', None):
+                string = string.replace("{UserId}", self.config.data['auth.user_id'])
+            else:
+                LOG.debug("UserId is not set.")
+
+        if '{DeviceId}'in string:
+            if self.config.data.get('app.device_id', None):
+                string = string.replace("{DeviceId}", self.config.data['app.device_id'])
+            else:
+                LOG.debug("DeviceId is not set.")
+
+        return string
+
+    def request_url(self, data):
+        if not data:
+            raise AttributeError("Request cannot be empty")
+
+        data = self._request(data)
+
+        params = data["params"]
+        if "api_key" not in params:
+            params["api_key"] = self.config.data.get('auth.token')
+
+        encoded_params = urllib.parse.urlencode(data["params"])
+        return "%s?%s" % (data["url"], encoded_params)
+
+    async def request(self, data, session=None, dest_file=None):
+        if not data:
+            raise AttributeError("Request cannot be empty")
+
+        data = self._request(data)
+        LOG.debug("--->[ http ] %s", json.dumps(data, indent=4))
+        retry = data.pop('retry', 5)
+        stream = dest_file is not None
+
+        while True:
+            try:
+                method = data.pop('type', "GET")
+                response = await self._request_with_session(session, method, stream=stream, **data)
+                try:
+                    if stream:
+                        async for chunk in response.aiter_bytes(chunk_size=8192):
+                            if chunk:
+                                dest_file.write(chunk)
+                    else:
+                        await response.aread()
+
+                    if not self.keep_alive and self.session is not None:
+                        await self.stop_session()
+
+                    response.raise_for_status()
+                finally:
+                    await response.aclose()
+
+            except httpx.ConnectError as error:
+                if retry:
+                    retry -= 1
+                    await asyncio.sleep(1)
+                    continue
+
+                LOG.error(error)
+                self.client.callback("ServerUnreachable", {'ServerId': self.config.data['auth.server-id']})
+
+                raise HTTPException("ServerUnreachable", error)
+
+            except httpx.ReadTimeout as error:
+                if retry:
+                    retry -= 1
+                    await asyncio.sleep(1)
+                    continue
+
+                LOG.error(error)
+                raise HTTPException("ReadTimeout", error)
+
+            except httpx.HTTPStatusError as error:
+                LOG.error(error)
+                status_code = error.response.status_code
+
+                if status_code == 401:
+                    if 'X-Application-Error-Code' in error.response.headers:
+                        self.client.callback("AccessRestricted", {'ServerId': self.config.data['auth.server-id']})
+                        raise HTTPException("AccessRestricted", error)
+
+                    self.client.callback("Unauthorized", {'ServerId': self.config.data['auth.server-id']})
+                    if hasattr(self.client, "auth"):
+                        self.client.auth.revoke_token()
+                    raise HTTPException("Unauthorized", error)
+
+                if status_code == 500:
+                    LOG.error("--[ 500 response ] %s", error)
+                    return
+
+                if status_code == 502:
+                    if retry:
+                        retry -= 1
+                        await asyncio.sleep(1)
+                        continue
+
+                raise HTTPException(status_code, error)
+
+            except httpx.InvalidURL as error:
+                LOG.error("Request missing Schema. %s", error)
+                raise HTTPException("MissingSchema", {'Id': self.config.data.get('auth.server', "None")})
+
+            except Exception:
+                raise
+
+            else:
+                try:
+                    if stream:
+                        return
+                    self.config.data['server-time'] = response.headers['Date']
+                    elapsed = int(response.elapsed.total_seconds() * 1000)
+                    response_json = response.json()
+                    LOG.debug("---<[ http ][%s ms]", elapsed)
+                    LOG.debug(json.dumps(response_json, indent=4))
+
+                    return response_json
+                except ValueError:
+                    return
+
+    async def _request_with_session(self, session, action, stream=False, **kwargs):
+        active_session = session or self.session
+        if active_session is None:
+            async with self._create_client() as client:
+                return await self._requests(client, action, stream=stream, **kwargs)
+        return await self._requests(active_session, action, stream=stream, **kwargs)
+
+    async def _requests(self, session, action, stream=False, **kwargs):
+        if stream:
+            kwargs["stream"] = True
+        if action == "GET":
+            return await session.get(**kwargs)
+        if action == "POST":
+            return await session.post(**kwargs)
+        if action == "HEAD":
+            return await session.head(**kwargs)
+        if action == "DELETE":
+            return await session.delete(**kwargs)
+
+    def _request(self, data):
+        if 'url' not in data:
+            data['url'] = "%s/%s" % (self.config.data.get("auth.server", ""), data.pop('handler', ""))
+
+        headers = self._get_default_headers()
+        user_specified_headers = (data.get('headers', None) or {})
+        headers.update(user_specified_headers)
+
+        data['headers'] = headers
+        data['timeout'] = data.get('timeout') or self.config.data['http.timeout']
+        data['verify'] = data.get('verify') or self.config.data.get('auth.ssl', False)
+        data['url'] = self._replace_user_info(data['url'])
+        self._process_params(data.get('params') or {})
+        self._process_params(data.get('json') or {})
+
+        return data
+
+    def _process_params(self, params):
+        if isinstance(params, str):
+            return
+
+        for key in params:
+            value = params[key]
+
+            if isinstance(value, dict):
+                self._process_params(value)
+
+            if isinstance(value, str):
+                params[key] = self._replace_user_info(value)
+
+    def _get_authenication_header(self):
+        params = {}
+        if "app.device_name" in self.config.data:
+            params.update({
+                "Client": self.config.data['app.name'],
+                "Device": self.config.data['app.device_name'],
+                "DeviceId": self.config.data['app.device_id'],
+                "Version": self.config.data['app.version']
+                })
+        if "auth.token" in self.config.data:
+            params["Token"] = self.config.data['auth.token']
+        param_line = ", ".join(f'{k}="{v}"' for k, v in params.items())
+        return f"MediaBrowser {param_line}"
+
+    def _get_default_headers(self, content_type="application/json"):
+        app_name = f"{self.config.data.get('app.name', 'Jellyfin for Kodi')}/{self.config.data.get('app.version', '0.0.0')}"
+        return {
+            "Accept": "application/json",
+            "Content-type": content_type,
+            "X-Application": app_name,
+            "Accept-Charset": "UTF-8,*",
+            "Accept-encoding": "gzip",
+            "User-Agent": self.config.data['http.user_agent'] or app_name,
+            "Authorization": self._get_authenication_header()
+        }

--- a/jellyfin_apiclient_python/async_runner.py
+++ b/jellyfin_apiclient_python/async_runner.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+import threading
+
+
+class AsyncRunner:
+    """
+    Run asyncio coroutines in a dedicated background event loop thread.
+
+    This keeps sync API calls from blocking the caller's thread while reusing
+    a single event loop and async HTTP session for connection pooling.
+    """
+
+    def __init__(self):
+        self._loop = None
+        self._thread = None
+        self._ready = threading.Event()
+        self._closed = False
+        self._thread_id = None
+        self._start_loop_thread()
+
+    @property
+    def thread_id(self):
+        return self._thread_id
+
+    def _start_loop_thread(self):
+        def _run_loop():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._loop = loop
+            self._thread_id = threading.get_ident()
+            self._ready.set()
+            loop.run_forever()
+            pending = asyncio.all_tasks(loop)
+            if pending:
+                for task in pending:
+                    task.cancel()
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            loop.close()
+
+        self._thread = threading.Thread(
+            target=_run_loop,
+            daemon=True,
+            name="JellyfinAsyncRunner",
+        )
+        self._thread.start()
+        self._ready.wait()
+
+    def _raise_if_running_loop(self):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        raise RuntimeError(
+            "Sync JellyfinClient methods cannot be called from a running event loop. "
+            "Use the async API via client.aio instead."
+        )
+
+    def run(self, coro):
+        self._raise_if_running_loop()
+        if self._closed:
+            raise RuntimeError("AsyncRunner is closed.")
+        future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return future.result()
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        if self._loop is None:
+            return
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join()

--- a/jellyfin_apiclient_python/async_runner.py
+++ b/jellyfin_apiclient_python/async_runner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import asyncio
+import logging
 import threading
 
 
@@ -19,6 +20,8 @@ class AsyncRunner:
         self._closed = False
         self._thread_id = None
         self._start_loop_thread()
+
+        self._log = logging.getLogger("Jellyfin.AsyncRunner")
 
     @property
     def thread_id(self):
@@ -64,7 +67,11 @@ class AsyncRunner:
         if self._closed:
             raise RuntimeError("AsyncRunner is closed.")
         future = asyncio.run_coroutine_threadsafe(coro, self._loop)
-        return future.result()
+        try:
+            return future.result()
+        except Exception:
+            self._log.exception("Async task failed in AsyncRunner.")
+            raise
 
     def close(self):
         if self._closed:

--- a/jellyfin_apiclient_python/client.py
+++ b/jellyfin_apiclient_python/client.py
@@ -2,9 +2,12 @@
 
 #################################################################################################
 
+import asyncio
 import logging
 
-from . import api
+from .async_api import AsyncAPI
+from .async_http import AsyncHTTP
+from .async_runner import AsyncRunner
 from .configuration import Config
 from .http import HTTP
 from .ws_client import WSClient
@@ -34,13 +37,20 @@ class JellyfinClient(object):
     def __init__(self, allow_multiple_clients=False):
         LOG.debug("JellyfinClient initializing...")
 
+        self._runner = AsyncRunner()
         self.config = Config()
-        self.http = HTTP(self)
+        self._async = AsyncJellyfinClient(
+            allow_multiple_clients=allow_multiple_clients,
+            config=self.config,
+        )
+        self.http = HTTP(self, async_http=self._async.http, runner=self._runner)
         self.wsc = WSClient(self, allow_multiple_clients)
         self.auth = ConnectionManager(self)
-        self.jellyfin = api.API(self.http)
+        self.jellyfin = _SyncAPIProxy(self._async.jellyfin, self._runner)
         self.callback_ws = callback
         self.callback = callback
+        self._async.callback = self.callback
+        self._async.callback_ws = self.callback_ws
         self.timesync = TimeSyncManager(self)
 
     def set_credentials(self, credentials=None):
@@ -81,6 +91,68 @@ class JellyfinClient(object):
         self.wsc.start()
 
     def stop(self):
+        self.close()
+
+    def close(self):
         self.wsc.stop_client()
-        self.http.stop_session()
         self.timesync.stop_ping()
+        try:
+            self._runner.run(self._async.aclose())
+        finally:
+            self._runner.close()
+
+    @property
+    def aio(self):
+        return self._async
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb):
+        self.close()
+
+
+class AsyncJellyfinClient(object):
+
+    logged_in = False
+
+    def __init__(self, allow_multiple_clients=False, config=None):
+        LOG.debug("AsyncJellyfinClient initializing...")
+
+        self.config = config or Config()
+        self.http = AsyncHTTP(self)
+        self.jellyfin = AsyncAPI(self.http)
+        self.callback_ws = callback
+        self.callback = callback
+
+    async def aclose(self):
+        await self.http.stop_session()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, exc_tb):
+        await self.aclose()
+
+
+class _SyncAPIProxy:
+
+    def __init__(self, async_api, runner):
+        self._async_api = async_api
+        self._runner = runner
+
+    def __getattr__(self, name):
+        attr = getattr(self._async_api, name)
+        if callable(attr):
+            def wrapper(*args, **kwargs):
+                result = attr(*args, **kwargs)
+                if asyncio.iscoroutine(result):
+                    try:
+                        return self._runner.run(result)
+                    except RuntimeError:
+                        result.close()
+                        raise
+                return result
+
+            return wrapper
+        return attr

--- a/jellyfin_apiclient_python/connection_manager.py
+++ b/jellyfin_apiclient_python/connection_manager.py
@@ -14,7 +14,6 @@ import urllib3
 
 from .credentials import Credentials
 from .api import API
-from .http import HTTP
 import traceback
 
 #################################################################################################
@@ -40,7 +39,7 @@ class ConnectionManager(object):
         self.client = client
         self.config = client.config
         self.credentials = Credentials()
-        self.API = API(HTTP(client))
+        self.API = API(client.http)
 
         self.session = None
 

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -47,3 +47,9 @@ class HTTP:
         return self._runner.run(
             self._async_http.request(data, session=session, dest_file=dest_file)
         )
+
+    def _get_authenication_header(self):
+        return self._async_http._get_authenication_header()
+
+    def _get_default_headers(self, content_type="application/json"):
+        return self._async_http._get_default_headers(content_type=content_type)

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -2,278 +2,48 @@
 
 #################################################################################################
 
-import json
-import logging
-import time
-import urllib
-
-import requests
-
-from .exceptions import HTTPException
+from .async_http import AsyncHTTP
+from .async_runner import AsyncRunner
 
 #################################################################################################
 
-LOG = logging.getLogger('Jellyfin.' + __name__)
+class HTTP:
+    """
+    Synchronous HTTP adapter that delegates to AsyncHTTP via AsyncRunner.
+    """
 
-#################################################################################################
-
-
-class HTTP(object):
-
-    session = None
-    keep_alive = False
-
-    def __init__(self, client):
-
+    def __init__(self, client, async_http=None, runner=None):
         self.client = client
         self.config = client.config
+        self._async_http = async_http or AsyncHTTP(client)
+        self._runner = runner or getattr(client, "_runner", None) or AsyncRunner()
+
+    @property
+    def session(self):
+        return self._async_http.session
+
+    @session.setter
+    def session(self, value):
+        self._async_http.session = value
+
+    @property
+    def keep_alive(self):
+        return self._async_http.keep_alive
+
+    @keep_alive.setter
+    def keep_alive(self, value):
+        self._async_http.keep_alive = value
 
     def start_session(self):
-        self.session = requests.Session()
-
-        max_retries = self.config.data['http.max_retries']
-
-        # Configure the session for tls client authentication
-        if 'auth.tls_client_cert' in self.client.config.data and 'auth.tls_client_key' in self.client.config.data:
-            self.session.cert = (self.client.config.data['auth.tls_client_cert'],
-                                 self.client.config.data['auth.tls_client_key'])
-
-            if self.client.config.data['auth.tls_server_ca']:
-                self.session.verify = self.client.config.data['auth.tls_server_ca']
-
-        self.session.mount("http://", requests.adapters.HTTPAdapter(max_retries=max_retries))
-        self.session.mount("https://", requests.adapters.HTTPAdapter(max_retries=max_retries))
+        return self._runner.run(self._async_http.start_session())
 
     def stop_session(self):
-
-        if self.session is None:
-            return
-
-        try:
-            LOG.info("--<[ session/%s ]", id(self.session))
-            self.session.close()
-        except Exception as error:
-            LOG.warning("The requests session could not be terminated: %s", error)
-
-    def _replace_user_info(self, string):
-
-        if '{server}' in string:
-            if self.config.data.get('auth.server', None):
-                string = string.replace("{server}", self.config.data['auth.server'])
-            else:
-                LOG.debug("Server address not set")
-
-        if '{UserId}'in string:
-            if self.config.data.get('auth.user_id', None):
-                string = string.replace("{UserId}", self.config.data['auth.user_id'])
-            else:
-                LOG.debug("UserId is not set.")
-
-        if '{DeviceId}'in string:
-            if self.config.data.get('app.device_id', None):
-                string = string.replace("{DeviceId}", self.config.data['app.device_id'])
-            else:
-                LOG.debug("DeviceId is not set.")
-
-        return string
+        return self._runner.run(self._async_http.stop_session())
 
     def request_url(self, data):
-        if not data:
-            raise AttributeError("Request cannot be empty")
-
-        data = self._request(data)
-
-        params = data["params"]
-        if "api_key" not in params:
-            params["api_key"] = self.config.data.get('auth.token')
-
-        encoded_params = urllib.parse.urlencode(data["params"])
-        return "%s?%s" % (data["url"], encoded_params)
+        return self._async_http.request_url(data)
 
     def request(self, data, session=None, dest_file=None):
-
-        ''' Give a chance to retry the connection. Jellyfin sometimes can be slow to answer back
-            data dictionary can contain:
-            type: GET, POST, etc.
-            url: (optional)
-            handler: not considered when url is provided (optional)
-            params: request parameters (optional)
-            json: request body (optional)
-            headers: (optional),
-            verify: ssl certificate, True (verify using device built-in library) or False
-        '''
-        if not data:
-            raise AttributeError("Request cannot be empty")
-
-        data = self._request(data)
-        LOG.debug("--->[ http ] %s", json.dumps(data, indent=4))
-        retry = data.pop('retry', 5)
-        stream = dest_file is not None
-
-        server_id = None
-        if 'auth.server-id' in self.config.data:
-            server_id = self.config.data['auth.server-id']
-
-        while True:
-
-            try:
-                r = self._requests(session or self.session or requests, data.pop('type', "GET"), **data, stream=stream)
-                if stream:
-                    for chunk in r.iter_content(chunk_size=8192):
-                        if chunk: # filter out keep-alive new chunks
-                            dest_file.write(chunk)
-                else:
-                    r.content  # release the connection
-
-                if not self.keep_alive and self.session is not None:
-                    self.stop_session()
-
-                r.raise_for_status()
-
-            except requests.exceptions.ConnectionError as error:
-                if retry:
-
-                    retry -= 1
-                    time.sleep(1)
-
-                    continue
-
-                LOG.error(error)
-                if server_id is not None:
-                    self.client.callback("ServerUnreachable", {'ServerId': server_id})
-
-                raise HTTPException("ServerUnreachable", error)
-
-            except requests.exceptions.ReadTimeout as error:
-                if retry:
-
-                    retry -= 1
-                    time.sleep(1)
-
-                    continue
-
-                LOG.error(error)
-
-                raise HTTPException("ReadTimeout", error)
-
-            except requests.exceptions.HTTPError as error:
-                LOG.error(error)
-
-                if r.status_code == 401:
-
-                    if 'X-Application-Error-Code' in r.headers:
-                        if server_id is not None:
-                            self.client.callback("AccessRestricted", {'ServerId': server_id})
-
-                        raise HTTPException("AccessRestricted", error)
-                    else:
-                        if server_id is not None:
-                            self.client.callback("Unauthorized", {'ServerId': server_id})
-                        self.client.auth.revoke_token()
-
-                        raise HTTPException("Unauthorized", error)
-
-                elif r.status_code == 500:  # log and ignore.
-                    LOG.error("--[ 500 response ] %s", error)
-
-                    return
-
-                elif r.status_code == 502:
-                    if retry:
-
-                        retry -= 1
-                        time.sleep(1)
-
-                        continue
-
-                raise HTTPException(r.status_code, error)
-
-            except requests.exceptions.MissingSchema as error:
-                LOG.error("Request missing Schema. " + str(error))
-                raise HTTPException("MissingSchema", {'Id': self.config.data.get('auth.server', "None")})
-
-            except Exception:
-                raise
-
-            else:
-                try:
-                    if stream:
-                        return
-                    self.config.data['server-time'] = r.headers['Date']
-                    elapsed = int(r.elapsed.total_seconds() * 1000)
-                    response = r.json()
-                    LOG.debug("---<[ http ][%s ms]", elapsed)
-                    LOG.debug(json.dumps(response, indent=4))
-
-                    return response
-                except ValueError:
-                    return
-
-    def _request(self, data):
-
-        if 'url' not in data:
-            data['url'] = "%s/%s" % (self.config.data.get("auth.server", ""), data.pop('handler', ""))
-
-        headers = self._get_default_headers()
-        user_specified_headers = (data.get('headers', None) or {})
-        headers.update(user_specified_headers)
-
-        data['headers'] = headers
-        data['timeout'] = data.get('timeout') or self.config.data['http.timeout']
-        data['verify'] = data.get('verify') or self.config.data.get('auth.ssl', False)
-        data['url'] = self._replace_user_info(data['url'])
-        self._process_params(data.get('params') or {})
-        self._process_params(data.get('json') or {})
-
-        return data
-
-    def _process_params(self, params):
-        if isinstance(params, str):
-            # Json is being used as data
-            return
-
-        for key in params:
-            value = params[key]
-
-            if isinstance(value, dict):
-                self._process_params(value)
-
-            if isinstance(value, str):
-                params[key] = self._replace_user_info(value)
-
-    def _get_authenication_header(self):
-        params = {}
-        if "app.device_name" in self.config.data:
-            params.update({
-                "Client": self.config.data['app.name'],
-                "Device": self.config.data['app.device_name'],
-                "DeviceId": self.config.data['app.device_id'],
-                "Version": self.config.data['app.version']
-                })
-        if "auth.token" in self.config.data:
-            params["Token"] = self.config.data['auth.token']
-        param_line = ", ".join(f'{k}="{v}"' for k, v in params.items())
-        return f"MediaBrowser {param_line}"
-
-    def _get_default_headers(self, content_type="application/json"):
-        app_name = f"{self.config.data.get('app.name', 'Jellyfin for Kodi')}/{self.config.data.get('app.version', '0.0.0')}"
-        return {
-            "Accept": "application/json",
-            "Content-type": content_type,
-            "X-Application": app_name,
-            "Accept-Charset": "UTF-8,*",
-            "Accept-encoding": "gzip",
-            "User-Agent": self.config.data['http.user_agent'] or app_name,
-            "Authorization": self._get_authenication_header()
-        }
-
-    def _requests(self, session, action, **kwargs):
-
-        if action == "GET":
-            return session.get(**kwargs)
-        elif action == "POST":
-            return session.post(**kwargs)
-        elif action == "HEAD":
-            return session.head(**kwargs)
-        elif action == "DELETE":
-            return session.delete(**kwargs)
+        return self._runner.run(
+            self._async_http.request(data, session=session, dest_file=dest_file)
+        )

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -7,6 +7,7 @@ from .async_runner import AsyncRunner
 
 #################################################################################################
 
+
 class HTTP:
     """
     Synchronous HTTP adapter that delegates to AsyncHTTP via AsyncRunner.

--- a/jellyfin_apiclient_python/httpx_compat.py
+++ b/jellyfin_apiclient_python/httpx_compat.py
@@ -124,6 +124,10 @@ else:
             return await self.request("DELETE", url, **kwargs)
 
         def _sync_request(self, method, url, **kwargs):
+            if "verify" not in kwargs and self._verify is not None:
+                kwargs["verify"] = self._verify
+            if "cert" not in kwargs and self._cert is not None:
+                kwargs["cert"] = self._cert
             try:
                 response = requests.request(method, url, **kwargs)
                 elapsed = type("Elapsed", (), {"total_seconds": lambda self: response.elapsed.total_seconds()})()

--- a/jellyfin_apiclient_python/httpx_compat.py
+++ b/jellyfin_apiclient_python/httpx_compat.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+import importlib
+import importlib.util
+import json
+from dataclasses import dataclass
+
+import requests
+
+
+def _load_httpx():
+    spec = importlib.util.find_spec("httpx")
+    if spec is None:
+        return None
+    return importlib.import_module("httpx")
+
+
+_real_httpx = _load_httpx()
+
+
+if _real_httpx is not None:
+    httpx = _real_httpx
+else:
+    class ConnectError(Exception):
+        pass
+
+    class ReadTimeout(Exception):
+        pass
+
+    class InvalidURL(Exception):
+        pass
+
+    class HTTPStatusError(Exception):
+        def __init__(self, message, response):
+            super().__init__(message)
+            self.response = response
+
+    @dataclass
+    class Request:
+        method: str
+        url: str
+        headers: dict
+        content: bytes
+
+    jsonlib = json
+
+    class Response:
+        def __init__(self, status_code, json=None, headers=None, content=None, url=None, elapsed=None):
+            self.status_code = status_code
+            self.headers = headers or {}
+            self._json = json
+            if content is None and json is not None:
+                content = jsonlib.dumps(json).encode("utf-8")
+            self.content = content or b""
+            self.url = url
+            self.elapsed = elapsed or type("Elapsed", (), {"total_seconds": lambda self: 0})()
+
+        def json(self):
+            if self._json is not None:
+                return self._json
+            return jsonlib.loads(self.content.decode("utf-8"))
+
+        def raise_for_status(self):
+            if 400 <= self.status_code:
+                raise HTTPStatusError(f"Status code {self.status_code}", self)
+
+        async def aread(self):
+            return self.content
+
+        async def aiter_bytes(self, chunk_size=8192):
+            for i in range(0, len(self.content), chunk_size):
+                yield self.content[i:i + chunk_size]
+
+        async def aclose(self):
+            return
+
+    class MockTransport:
+        def __init__(self, handler):
+            self._handler = handler
+
+        async def handle_async_request(self, request):
+            return self._handler(request)
+
+    class AsyncClient:
+        def __init__(self, transport=None, timeout=None, verify=None, cert=None):
+            self._transport = transport
+            self._timeout = timeout
+            self._verify = verify
+            self._cert = cert
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, exc_tb):
+            await self.aclose()
+
+        async def aclose(self):
+            return
+
+        async def request(self, method, url, **kwargs):
+            if self._transport is not None:
+                request = Request(
+                    method=method.upper(),
+                    url=url,
+                    headers=kwargs.get("headers") or {},
+                    content=kwargs.get("content") or b"",
+                )
+                response = await self._transport.handle_async_request(request)
+                response.url = response.url or url
+                return response
+            return await asyncio.to_thread(self._sync_request, method, url, **kwargs)
+
+        async def get(self, url, **kwargs):
+            return await self.request("GET", url, **kwargs)
+
+        async def post(self, url, **kwargs):
+            return await self.request("POST", url, **kwargs)
+
+        async def head(self, url, **kwargs):
+            return await self.request("HEAD", url, **kwargs)
+
+        async def delete(self, url, **kwargs):
+            return await self.request("DELETE", url, **kwargs)
+
+        def _sync_request(self, method, url, **kwargs):
+            try:
+                response = requests.request(method, url, **kwargs)
+                elapsed = type("Elapsed", (), {"total_seconds": lambda self: response.elapsed.total_seconds()})()
+                return Response(
+                    response.status_code,
+                    headers=dict(response.headers),
+                    content=response.content,
+                    url=response.url,
+                    elapsed=elapsed,
+                )
+            except requests.exceptions.ConnectionError as error:
+                raise ConnectError(error) from error
+            except requests.exceptions.ReadTimeout as error:
+                raise ReadTimeout(error) from error
+            except requests.exceptions.MissingSchema as error:
+                raise InvalidURL(error) from error
+
+    httpx = type(
+        "httpx",
+        (),
+        {
+            "AsyncClient": AsyncClient,
+            "MockTransport": MockTransport,
+            "Response": Response,
+            "ConnectError": ConnectError,
+            "ReadTimeout": ReadTimeout,
+            "HTTPStatusError": HTTPStatusError,
+            "InvalidURL": InvalidURL,
+        },
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 requires-python='>=3.6'
 dependencies=[
     'requests',
+    'httpx',
     'urllib3',
     'websocket_client',
     'certifi'

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 
 from jellyfin_apiclient_python.httpx_compat import httpx
 import pytest
@@ -64,3 +65,54 @@ def test_sync_api_called_from_event_loop_raises():
 
     asyncio.run(run())
     client.close()
+
+
+def test_async_stream_writes_bytes_and_closes_session():
+    # This covers the streaming path to ensure we do not attempt JSON parsing,
+    # and that keep-alive disabled sessions are still closed after a request.
+    async_client = AsyncJellyfinClient()
+    _configure_client(async_client)
+    async_client.http.keep_alive = False
+    async_client.http.session = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                200,
+                content=b"jellyfin-stream",
+                headers={"Date": "Mon, 01 Jan 2024 00:00:00 GMT"},
+            )
+        )
+    )
+    buffer = io.BytesIO()
+
+    async def run():
+        await async_client.http.request(
+            {"type": "GET", "url": "https://example.com/stream"},
+            dest_file=buffer,
+        )
+
+    asyncio.run(run())
+
+    assert buffer.getvalue() == b"jellyfin-stream"
+    assert async_client.http.session is None
+
+
+def test_async_keep_alive_retains_session_for_multiple_requests():
+    # This ensures keep-alive preserves the shared async session across calls.
+    async_client = AsyncJellyfinClient()
+    _configure_client(async_client)
+    async_client.http.keep_alive = True
+    async_client.http.session = httpx.AsyncClient(transport=_mock_transport())
+    session_id = id(async_client.http.session)
+
+    async def run():
+        first = await async_client.jellyfin.get_system_info()
+        second = await async_client.jellyfin.get_system_info()
+        return first, second
+
+    first, second = asyncio.run(run())
+
+    assert first == {"Name": "Jellyfin"}
+    assert second == {"Name": "Jellyfin"}
+    assert async_client.http.session is not None
+    assert id(async_client.http.session) == session_id
+    asyncio.run(async_client.aclose())

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,66 @@
+import asyncio
+
+from jellyfin_apiclient_python.httpx_compat import httpx
+import pytest
+
+from jellyfin_apiclient_python.client import AsyncJellyfinClient, JellyfinClient
+
+
+def _mock_transport():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={"Name": "Jellyfin"},
+            headers={"Date": "Mon, 01 Jan 2024 00:00:00 GMT"},
+        )
+
+    return httpx.MockTransport(handler)
+
+
+def _configure_client(client):
+    client.config.data["auth.server"] = "https://example.com"
+    client.config.data["auth.token"] = "token"
+
+
+def test_async_api_returns_payload():
+    async_client = AsyncJellyfinClient()
+    _configure_client(async_client)
+    async_client.http.keep_alive = True
+    async_client.http.session = httpx.AsyncClient(transport=_mock_transport())
+
+    async def run():
+        response = await async_client.jellyfin.get_system_info()
+        assert response == {"Name": "Jellyfin"}
+        await async_client.aclose()
+
+    asyncio.run(run())
+
+
+def test_sync_api_reuses_runner_thread():
+    client = JellyfinClient()
+    _configure_client(client)
+    client.aio.http.keep_alive = True
+    client.aio.http.session = httpx.AsyncClient(transport=_mock_transport())
+    thread_id = client._runner.thread_id
+
+    first = client.jellyfin.get_system_info()
+    second = client.jellyfin.get_system_info()
+
+    assert first == {"Name": "Jellyfin"}
+    assert second == {"Name": "Jellyfin"}
+    assert client._runner.thread_id == thread_id
+    client.close()
+
+
+def test_sync_api_called_from_event_loop_raises():
+    client = JellyfinClient()
+    _configure_client(client)
+    client.aio.http.keep_alive = True
+    client.aio.http.session = httpx.AsyncClient(transport=_mock_transport())
+
+    async def run():
+        with pytest.raises(RuntimeError, match="async API"):
+            client.jellyfin.get_system_info()
+
+    asyncio.run(run())
+    client.close()


### PR DESCRIPTION
The idea of this PR is to use async http requests to for the core network logic, and then refactor the existing API so it utilizes that transparently behind the scenes. This means that existing code should continue to work, but now the original HTTP class is a think wrapper around an async variant that does the work. It does require a new httpx dependency. 

I don't think this will have an effect on the speed of existing code, but it should enable much more performant queries if new code uses the async logic. 

The diff was generated almost entirely with GPT codex with 2 prompts. I did a manual fold in of #60 and a rebase because I used codex on the wrong HEAD commit. 

I'm still testing to ensure there are no issues, but so far I don't think I broke anything.

This is marked as a draft because I want to:

* Double check the AI work.
* Add more unit tests to ensure coverage.
* Verify that it works in my pipeline and measure the speedup. 