### PR TITLE
Add support for the Jellyfin Backup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The test suite is run via `tox`, and you can install it from PyPi.
  - Add support for authenticating via an API key
  - Add support for the optional 'date played' parameter in the `item_played` API method
  - Add API calls `get_userdata_for_item` and `update_userdata_for_item`
+ - Add support for the backup API introduced in Jellyfin 10.11.0
 
 ## Contributing
 

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -1276,8 +1276,132 @@ class CollectionAPIMixin:
         return self._delete(f"Collections/{collection_id}/Items", json, params)
 
 
-class API(InternalAPIMixin, BiggerAPIMixin, GranularAPIMixin,
-          SyncPlayAPIMixin, ExperimentalAPIMixin, CollectionAPIMixin):
+class BackupAPIMixin:
+    """
+    Methods for creating, restoring and listing system backups
+
+    10.11.0+ only
+
+    Note: backup manifests are dictionary objects with the following structure:
+
+        {
+            "ServerVersion": "string",
+            "BackupEngineVersion": "string",
+            "DateCreated": "2019-08-24T14:15:22Z",
+            "Path": "string",
+            "Options": {
+                "Metadata": true,
+                "Trickplay": true,
+                "Subtitles": true,
+                "Database": true
+            }
+        }
+
+    """
+
+    def create_backup(
+        self,
+        include_metadata: bool = False,
+        include_subtitles: bool = False,
+        include_trickplay: bool = False,
+    ):
+        """
+        Creates a new backup including the database and any of the optional
+        elements requested. If metadata is included, this can be a time-consuming
+        operation.
+
+        Args:
+            include_metadata (bool)
+                Whether or not to include metadata in the backup
+
+            include_subtitles (bool)
+                Whether or not to include subtitles in the backup
+
+            include_trickplay (bool)
+                Whether or not to include trickplay information in the backup
+
+        Returns:
+            The manifest of the backup if it was created, an empty directory
+            otherwise.
+
+        """
+        params = {
+            "database": True,
+            "metadata": include_metadata,
+            "subtitles": include_subtitles,
+            "trickplay": include_trickplay,
+        }
+        return self._post("Backup/Create", params)
+
+    def get_backup_manifest(self, path: str):
+        """
+        Gets the manifest of a backup at the path passed
+
+        Args:
+            path (str):
+                Location of the backup
+
+        Returns:
+            The backup's manifest, if the backup exists, an empty dictionary
+            otherwise.
+
+        References:
+            .. [BackupManifest] https://api.jellyfin.org/#tag/Backup/operation/GetBackup
+        """
+        params = {"path": path}
+        return self._get("Backup/Manifest", params)
+
+    def get_backups(self):
+        """
+        Gets a list of all currently present backups in the backup directory.
+
+        Args:
+            None
+
+        Returns:
+            List of manifests for the backup that exist, one per backup.
+
+        References:
+            .. [Backup] https://api.jellyfin.org/#tag/Backup/operation/ListBackups
+        """
+        return self._get("Backup")
+
+    def restore_backup(self, backup_name: str):
+        """
+        Starts the process of restoring a backup with the name passed.
+
+        Args:
+            backup_name (str)
+                The name of the backup archive, which must exist in the
+                backups directory for the restore process to start
+
+        Returns:
+            True if the restore process started, False otherwise
+
+        """
+        params = {"ArchiveFileName": backup_name}
+        try:
+            # This post call returns a 204 to indicate that the restore has
+            # been requested, but the client ingests the non-error code
+            # and the _post() call returns nothing.
+            self._post("Backup/Restore", params)
+            return True
+
+        except Exception as e:
+            LOG.error(e)
+
+        return False
+
+
+class API(
+    InternalAPIMixin,
+    BiggerAPIMixin,
+    GranularAPIMixin,
+    SyncPlayAPIMixin,
+    ExperimentalAPIMixin,
+    CollectionAPIMixin,
+    BackupAPIMixin,
+):
     """
     The Jellyfin Python API client containing all api calls to the server.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,13 +1,104 @@
-from jellyfin_apiclient_python.api import jellyfin_url
-from unittest.mock import Mock
+from jellyfin_apiclient_python.api import jellyfin_url, API
+from jellyfin_apiclient_python.http import HTTP
+from unittest.mock import Mock, patch
+from unittest import TestCase
+
 
 def test_jellyfin_url_handles_trailing_slash():
     mock_client = Mock()
-    mock_client.config.data = {'auth.server': 'https://example.com/'}
+    mock_client.config.data = {"auth.server": "https://example.com/"}
     handler = "Items/1234"
     url = jellyfin_url(mock_client, handler)
     assert url == "https://example.com/Items/1234"
 
-    mock_client.config.data = {'auth.server': 'https://example.com'}
+    mock_client.config.data = {"auth.server": "https://example.com"}
     url = jellyfin_url(mock_client, handler)
     assert url == "https://example.com/Items/1234"
+
+
+class TestBackup(TestCase):
+    def setup_requests(self):
+        patcher = patch("jellyfin_apiclient_python.http.HTTP.request")
+        self.addCleanup(patcher.stop)
+        self.mock_request = patcher.start()
+
+    def setup_api(self):
+        mock_client = Mock()
+        self.api = API(HTTP(mock_client))
+
+    def setUp(self):
+        self.setup_requests()
+        self.setup_api()
+
+    def assert_request_matches_call_parameters(
+        self, handler, params=None, json={}
+    ) -> None:
+        parameters = self.mock_request.call_args.args[0]
+
+        if parameters["type"] == "GET":
+            assert parameters["handler"] == handler
+            assert parameters["params"] == params
+
+        if parameters["type"] == "POST":
+            assert parameters["handler"] == handler
+            assert parameters["params"] == params
+            assert parameters["json"] == json
+
+    def test_create_backup_defaults_are_as_expected(self):
+        handler = "Backup/Create"
+        json = {
+            "database": True,
+            "metadata": False,
+            "subtitles": False,
+            "trickplay": False,
+        }
+        self.api.create_backup()
+
+        self.mock_request.assert_called_once()
+        self.assert_request_matches_call_parameters(handler=handler, json=json)
+
+    def test_create_backup_parameters_are_propagated(self):
+        handler = "Backup/Create"
+        json = {
+            "database": True,
+            "metadata": True,
+            "subtitles": True,
+            "trickplay": True,
+        }
+
+        self.api.create_backup(
+            include_metadata=True,
+            include_subtitles=True,
+            include_trickplay=True,
+        )
+
+        self.mock_request.assert_called_once()
+        self.assert_request_matches_call_parameters(handler=handler, json=json)
+
+    def test_get_backup_manifest_parameters_are_propagated(self):
+        handler = "Backup/Manifest"
+        path = "imaginary_path"
+        params = {"path": path}
+
+        self.api.get_backup_manifest(path=path)
+
+        self.mock_request.assert_called_once()
+        self.assert_request_matches_call_parameters(handler=handler, params=params)
+
+    def test_get_backups_has_no_patameters(self):
+        handler = "Backup"
+
+        self.api.get_backups()
+
+        self.mock_request.assert_called_once()
+        self.assert_request_matches_call_parameters(handler=handler)
+
+    def test_restore_backup_parameters_are_propagated(self):
+        handler = "Backup/Restore"
+        backup_name = "imaginary_name"
+        json = {"ArchiveFileName": backup_name}
+
+        self.api.restore_backup(backup_name=backup_name)
+
+        self.mock_request.assert_called_once()
+        self.assert_request_matches_call_parameters(handler=handler, json=json)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint,
-    py{38,39,310,311,312},
+    py{38,39,310,311,312,313},
 
 [gh-actions]
 python =
@@ -10,6 +10,7 @@ python =
     3.10: py310, lint
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 deps =


### PR DESCRIPTION
Resolves #74 by adding methods wrapping the four API calls that make up the Backup API.

Unit tests have been added and README.md updated accordingly.

The tox test environments have been extended to include Python 3.13.

tox passes lint and all test environments successfully other than Python 3.8, which is skipped by tox itself.