### PR TITLE
Add Quick Connect authentication support

### DIFF
--- a/jellyfin_apiclient_python/__init__.py
+++ b/jellyfin_apiclient_python/__init__.py
@@ -8,7 +8,7 @@ from .client import JellyfinClient
 
 #################################################################################################
 
-__version__ = '1.12.0'
+__version__ = '1.13.0'
 
 
 class NullHandler(logging.Handler):

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -5,6 +5,7 @@ For API info see:
 """
 from typing import List
 from datetime import datetime
+from urllib.parse import quote
 import requests
 import json
 import logging
@@ -821,6 +822,90 @@ class GranularAPIMixin:
 
                 return {}
         except Exception as e:  # Find exceptions for likely cases i.e, server timeout, etc
+            LOG.error(e)
+
+        return {}
+
+    def quick_connect_enabled(self, server_url, session=None):
+        """Return whether Quick Connect is enabled on the server."""
+        try:
+            response = self.send_request(
+                server_url, "QuickConnect/Enabled", session=session
+            )
+            if response.status_code == 200:
+                return bool(response.json())
+            LOG.error(
+                "Failed to query Quick Connect status: " + str(response.status_code)
+            )
+        except Exception as e:
+            LOG.error(e)
+
+        return False
+
+    def quick_connect_initiate(self, server_url, session=None):
+        """Start a Quick Connect request, returning a dict with Secret and Code."""
+        headers = self.get_default_headers()
+
+        try:
+            response = self.send_request(
+                server_url, "QuickConnect/Initiate", method="post",
+                headers=headers, timeout=(5, 30), session=session
+            )
+            if response.status_code == 200:
+                return response.json()
+            LOG.error(
+                "Failed to initiate Quick Connect: " + str(response.status_code)
+            )
+        except Exception as e:
+            LOG.error(e)
+
+        return {}
+
+    def quick_connect_state(self, server_url, secret, session=None):
+        """Return the current state of a Quick Connect request as a dict.
+
+        The returned dict's ``Authenticated`` field indicates whether the user
+        has approved the request yet.
+        """
+        path = "QuickConnect/Connect?secret=" + quote(secret, safe="")
+
+        try:
+            response = self.send_request(server_url, path, session=session)
+            if response.status_code == 200:
+                return response.json()
+            LOG.error(
+                "Failed to query Quick Connect state: " + str(response.status_code)
+            )
+        except Exception as e:
+            LOG.error(e)
+
+        return {}
+
+    def login_with_quick_connect(self, server_url, secret, session=None):
+        """Exchange an authorized Quick Connect secret for an AuthenticationResult.
+
+        Returns the same payload shape as ``login()`` (AccessToken, User, ...)
+        on success, or an empty dict on failure.
+        """
+        path = "Users/AuthenticateWithQuickConnect"
+        authData = {"Secret": secret}
+
+        headers = self.get_default_headers()
+        headers.update({'Content-type': "application/json"})
+
+        try:
+            response = self.send_request(
+                server_url, path, method="post", headers=headers,
+                data=json.dumps(authData), timeout=(5, 30), session=session
+            )
+            if response.status_code == 200:
+                return response.json()
+            LOG.error(
+                "Failed to authenticate with Quick Connect, status code: "
+                + str(response.status_code)
+            )
+            LOG.error("Server Response:\n" + str(response.content))
+        except Exception as e:
             LOG.error(e)
 
         return {}

--- a/jellyfin_apiclient_python/connection_manager.py
+++ b/jellyfin_apiclient_python/connection_manager.py
@@ -126,6 +126,31 @@ class ConnectionManager(object):
             return {}
 
         LOG.info("Succesfully logged in as %s" % (username))
+        return self._persist_authentication(data)
+
+
+    def login_with_quick_connect(self, server_url, secret):
+
+        if not secret:
+            raise AttributeError("secret cannot be empty")
+
+        if not server_url:
+            raise AttributeError("server url cannot be empty")
+
+        data = self.API.login_with_quick_connect(server_url, secret, self.session) # returns empty dict on failure
+
+        if not data:
+            LOG.info("Failed to log in with Quick Connect")
+            return {}
+
+        LOG.info("Successfully logged in with Quick Connect")
+        return self._persist_authentication(data)
+
+
+    def _persist_authentication(self, data):
+        # Record an AuthenticationResult (from a password login or Quick
+        # Connect) in the credential store. Returns the data on success, or an
+        # empty dict if its server is not known to us.
         # TODO Change when moving to database storage of server details
         credentials = self.credentials.get()
 
@@ -149,7 +174,7 @@ class ConnectionManager(object):
             'Id': data['User']['Id'],
             'IsSignedInOffline': True
         }
-        self.credentials.add_update_user(server, info)
+        self.credentials.add_update_user(found_server, info)
 
         self.credentials.set_credentials(credentials)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ from jellyfin_apiclient_python.api import jellyfin_url, API
 from jellyfin_apiclient_python.http import HTTP
 from unittest.mock import Mock, patch
 from unittest import TestCase
+import json
 
 def test_jellyfin_url_handles_trailing_slash():
     mock_client = Mock()
@@ -162,4 +163,62 @@ class TestIdentify(TestCase):
 
         self.mock_request.assert_called_once()
         self.assert_request_matches_call_parameters(item_id, self.defaultParams, json)
+
+
+class TestQuickConnect(TestCase):
+    # The Quick Connect endpoints, like login(), go through send_request()
+    # directly rather than HTTP.request, so we mock send_request here.
+    def setUp(self):
+        self.api = API(HTTP(Mock()))
+        # The Mock client has no real config; stub header construction since
+        # these tests only care about path/method/body wiring.
+        patcher = patch.object(API, "get_default_headers", return_value={})
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    @staticmethod
+    def _response(status_code=200, payload=None):
+        response = Mock()
+        response.status_code = status_code
+        response.json.return_value = payload
+        response.content = b""
+        return response
+
+    def test_quick_connect_enabled_true(self):
+        with patch.object(API, "send_request", return_value=self._response(200, True)) as sr:
+            self.assertIs(self.api.quick_connect_enabled("https://s"), True)
+            self.assertEqual(sr.call_args.args[1], "QuickConnect/Enabled")
+
+    def test_quick_connect_enabled_failure_returns_false(self):
+        with patch.object(API, "send_request", return_value=self._response(401, None)):
+            self.assertIs(self.api.quick_connect_enabled("https://s"), False)
+
+    def test_quick_connect_initiate_returns_payload(self):
+        payload = {"Secret": "abc", "Code": "123456"}
+        with patch.object(API, "send_request", return_value=self._response(200, payload)) as sr:
+            self.assertEqual(self.api.quick_connect_initiate("https://s"), payload)
+            self.assertEqual(sr.call_args.args[1], "QuickConnect/Initiate")
+            self.assertEqual(sr.call_args.kwargs["method"], "post")
+
+    def test_quick_connect_initiate_failure_returns_empty(self):
+        with patch.object(API, "send_request", return_value=self._response(401, None)):
+            self.assertEqual(self.api.quick_connect_initiate("https://s"), {})
+
+    def test_quick_connect_state_encodes_secret(self):
+        payload = {"Authenticated": False}
+        with patch.object(API, "send_request", return_value=self._response(200, payload)) as sr:
+            self.assertEqual(self.api.quick_connect_state("https://s", "a/b c"), payload)
+            self.assertEqual(sr.call_args.args[1], "QuickConnect/Connect?secret=a%2Fb%20c")
+
+    def test_login_with_quick_connect_returns_auth_result(self):
+        payload = {"AccessToken": "t", "User": {"Id": "u"}, "ServerId": "s"}
+        with patch.object(API, "send_request", return_value=self._response(200, payload)) as sr:
+            self.assertEqual(self.api.login_with_quick_connect("https://s", "secret"), payload)
+            self.assertEqual(sr.call_args.args[1], "Users/AuthenticateWithQuickConnect")
+            self.assertEqual(sr.call_args.kwargs["method"], "post")
+            self.assertEqual(json.loads(sr.call_args.kwargs["data"]), {"Secret": "secret"})
+
+    def test_login_with_quick_connect_failure_returns_empty(self):
+        with patch.object(API, "send_request", return_value=self._response(400, None)):
+            self.assertEqual(self.api.login_with_quick_connect("https://s", "secret"), {})
 

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from jellyfin_apiclient_python.api import API
 from jellyfin_apiclient_python.client import JellyfinClient, Config
@@ -67,4 +68,31 @@ class TestConnectionManager(unittest.TestCase):
         self.manager.credentials.set({"Servers": [server]})
         self.manager.server_id = 4
         self.assertEqual(self.manager.jellyfin_token(), 68)
+
+    def test_login_with_quick_connect_persists_credentials(self):
+        self.manager.credentials.set({"Servers": [{"Id": "srv"}]})
+        auth_result = {
+            "AccessToken": "tok",
+            "ServerId": "srv",
+            "User": {"Id": "user-1"},
+        }
+        with patch.object(API, "login_with_quick_connect", return_value=auth_result):
+            result = self.manager.login_with_quick_connect("https://s", "secret")
+
+        self.assertEqual(result, auth_result)
+        server = self.manager.credentials.get()["Servers"][0]
+        self.assertEqual(server["AccessToken"], "tok")
+        self.assertEqual(server["UserId"], "user-1")
+        self.assertEqual(self.manager.config.data["auth.token"], "tok")
+        self.assertEqual(self.manager.config.data["auth.user_id"], "user-1")
+
+    def test_login_with_quick_connect_failure_returns_empty(self):
+        with patch.object(API, "login_with_quick_connect", return_value={}):
+            self.assertEqual(
+                self.manager.login_with_quick_connect("https://s", "secret"), {}
+            )
+
+    def test_login_with_quick_connect_requires_secret(self):
+        with self.assertRaises(AttributeError):
+            self.manager.login_with_quick_connect("https://s", "")
 


### PR DESCRIPTION
## Summary

Adds support for Jellyfin's **Quick Connect** flow to the API client. This lets consumers authenticate a device without a password — the user approves a short code from an already-signed-in Jellyfin session. It's more convenient generally, and it's the only practical path for accounts that have no local password (e.g. users who sign in through an SSO/OpenID provider).

This is split out from a downstream change in `jellyfin-mpv-shim`, where the same flow had to be hand-rolled against the HTTP layer; it belongs here next to `login()`.

## Changes

**`api.py`** — four endpoint methods, mirroring `login()`'s style (`get_default_headers` → `send_request` → parsed JSON or empty/`False` on failure):

| Method | Endpoint |
|---|---|
| `quick_connect_enabled(server_url)` | `GET QuickConnect/Enabled` |
| `quick_connect_initiate(server_url)` | `POST QuickConnect/Initiate` |
| `quick_connect_state(server_url, secret)` | `GET QuickConnect/Connect` |
| `login_with_quick_connect(server_url, secret)` | `POST Users/AuthenticateWithQuickConnect` |

**`connection_manager.py`** — `login_with_quick_connect(server_url, secret)` exchanges an authorized secret for a session. The credential bookkeeping it shares with `login()` is factored out into `_persist_authentication()`, so both paths store credentials identically (no behavior change to `login()`).

**Polling** for authorization is intentionally left to the caller, keeping the library surface limited to the raw endpoints.

## Tests

Adds unit tests for all new methods (`tests/test_api.py`, `tests/test_connection_manager.py`), covering success and failure paths, request shape, and that the connection-manager path persists credentials. Version bumped to `1.13.0`.