### PR TITLE
Add get_playlist_items

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The test suite is run via `tox`, and you can install it from PyPi.
  - Add support for authenticating via an API key
  - Add support for the optional 'date played' parameter in the `item_played` API method
  - Add API calls `get_userdata_for_item` and `update_userdata_for_item`
+ - Add API call `get_playlist_items` for fetching a playlist's contents in order
  - Add support for the backup API introduced in Jellyfin 10.11.0
  - Extend the (currently) experimental `identify` API call to include all parameters supported by Jellyfin
 

--- a/jellyfin_apiclient_python/__init__.py
+++ b/jellyfin_apiclient_python/__init__.py
@@ -8,7 +8,7 @@ from .client import JellyfinClient
 
 #################################################################################################
 
-__version__ = '1.13.0'
+__version__ = '1.14.0'
 
 
 class NullHandler(logging.Handler):

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -185,6 +185,23 @@ class BiggerAPIMixin:
     def user_items(self, handler="", params=None):
         return self.users("/Items%s" % handler, params=params)
 
+    def get_playlist_items(self, playlist_id, fields=None, start_index=None,
+                           limit=None):
+        """Items of a playlist in playlist order (GET Playlists/{id}/Items).
+
+        Unlike a ``ParentId`` query, this preserves the user's playlist ordering
+        and returns each entry's ``PlaylistItemId``. ``UserId`` is filled from
+        the session so per-user data (played/resume) comes back.
+        """
+        params = {"UserId": "{UserId}"}
+        if fields is not None:
+            params["Fields"] = fields
+        if start_index is not None:
+            params["StartIndex"] = start_index
+        if limit is not None:
+            params["Limit"] = limit
+        return self._get("Playlists/%s/Items" % playlist_id, params)
+
     def shows(self, handler, params):
         return self._get("Shows%s" % handler, params)
 


### PR DESCRIPTION
Uses `GET Playlists/{id}/Items` to grab playlist items. Also bumps the version number.