### PR TITLE
Pin ruff to 0.15.21

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,13 @@ commands = pytest {posargs}
 basepython = python3.10
 skip_install = true
 deps =
-    ruff
+    # Pinned deliberately. There is no ruff config in this repo, so the linter
+    # runs on whatever its current release considers the default rule set, and
+    # 0.16.0 enabled families that were previously opt-in (UP031, B006, I001,
+    # BLE001, ...). That turned every open pull request red at once, on 144
+    # findings in code nobody had touched, and only in the 3.10 job — the one
+    # this env is tied to. Bump this on purpose, in a commit that also fixes
+    # whatever the new rules find.
+    ruff==0.15.21
 commands =
     ruff check --exit-non-zero-on-fix jellyfin_apiclient_python tests


### PR DESCRIPTION
`ruff` was running with a floating version and no config file. It updated, failing the existing repo, mainly over use of `%` formatters.

Pinning for now so rules are stable.