### PR TITLE
Fix legacy auth + feature additions for jf-web parity

### DIFF
--- a/jellyfin_apiclient_python/__init__.py
+++ b/jellyfin_apiclient_python/__init__.py
@@ -8,7 +8,7 @@ from .client import JellyfinClient
 
 #################################################################################################
 
-__version__ = '1.17.0'
+__version__ = '1.17.1'
 
 
 class NullHandler(logging.Handler):

--- a/jellyfin_apiclient_python/__init__.py
+++ b/jellyfin_apiclient_python/__init__.py
@@ -8,7 +8,7 @@ from .client import JellyfinClient
 
 #################################################################################################
 
-__version__ = '1.17.1'
+__version__ = '1.18.0'
 
 
 class NullHandler(logging.Handler):

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -52,10 +52,10 @@ class InternalAPIMixin:
 
         return self.client.request(request)
 
-    def _http_url(self, action, url, request={}):
+    def _http_url(self, action, url, request={}, include_apikey=True):
         request.update({"type": action, "handler": url})
 
-        return self.client.request_url(request)
+        return self.client.request_url(request, include_apikey=include_apikey)
 
     def _http_stream(self, action, url, dest_file, request={}):
         request.update({'type': action, 'handler': url})
@@ -65,8 +65,9 @@ class InternalAPIMixin:
     def _get(self, handler, params=None):
         return self._http("GET", handler, {'params': params})
 
-    def _get_url(self, handler, params=None):
-        return self._http_url("GET", handler, {"params": params})
+    def _get_url(self, handler, params=None, include_apikey=True):
+        return self._http_url("GET", handler, {"params": params},
+                              include_apikey=include_apikey)
 
     def _post(self, handler, json=None, params=None, data=None, headers=None):
         return self._http("POST", handler, {'params': params, 'json': json,
@@ -225,15 +226,18 @@ class BiggerAPIMixin:
     def media_segments(self, handler, params=None):
         return self._get("MediaSegments%s" % handler, params)
 
-    def artwork(self, item_id, art, max_width, ext="jpg", index=None):
+    def artwork(self, item_id, art, max_width, ext="jpg", index=None,
+                include_apikey=True):
         params = {"MaxWidth": max_width, "format": ext}
         handler = ("Items/%s/Images/%s" % (item_id, art) if index is None
                    else "items/%s/images/%s/%s" % (item_id, art, index)
                    )
 
-        return self._get_url(handler, params)
+        return self._get_url(handler, params,
+                             include_apikey=include_apikey)
 
-    def audio_url(self, item_id, container=None, audio_codec=None, max_streaming_bitrate=140000000):
+    def audio_url(self, item_id, container=None, audio_codec=None,
+                  max_streaming_bitrate=140000000, include_apikey=True):
         params = {
             "UserId": "{UserId}",
             "DeviceId": "{DeviceId}",
@@ -246,9 +250,10 @@ class BiggerAPIMixin:
         if audio_codec:
             params["AudioCodec"] = audio_codec
 
-        return self._get_url("Audio/%s/universal" % item_id, params)
+        return self._get_url("Audio/%s/universal" % item_id, params,
+                             include_apikey=include_apikey)
 
-    def video_url(self, item_id, media_source_id=None):
+    def video_url(self, item_id, media_source_id=None, include_apikey=True):
         params = {
             "static": "true",
             "DeviceId": "{DeviceId}"
@@ -256,14 +261,17 @@ class BiggerAPIMixin:
         if media_source_id is not None:
             params["MediaSourceId"] = media_source_id
 
-        return self._get_url("Videos/%s/stream" % item_id, params)
+        return self._get_url("Videos/%s/stream" % item_id, params,
+                             include_apikey=include_apikey)
 
-    def download_url(self, item_id):
+    def download_url(self, item_id, include_apikey=True):
         params = {}
-        return self._get_url("Items/%s/Download" % item_id, params)
+        return self._get_url("Items/%s/Download" % item_id, params,
+                             include_apikey=include_apikey)
 
     def image_url(self, item_id, image_type="Primary", index=None, tag=None,
-                  max_width=None, fill_width=None, fill_height=None, quality=90):
+                  max_width=None, fill_width=None, fill_height=None,
+                  quality=90, include_apikey=True):
         """Build an image URL for an item.
 
         Pass ``fill_width``/``fill_height`` to crop to an exact box, or
@@ -283,21 +291,26 @@ class BiggerAPIMixin:
             params["maxWidth"] = int(max_width)
         if tag is not None:
             params["tag"] = tag
-        return self._get_url(handler, params)
+        return self._get_url(handler, params,
+                             include_apikey=include_apikey)
 
-    def subtitle_url(self, item_id, media_source_id, index, fmt, fmt_index=0):
+    def subtitle_url(self, item_id, media_source_id, index, fmt, fmt_index=0,
+                     include_apikey=True):
         """Build the external-subtitle sidecar stream URL for one stream."""
         return self._get_url(
             "Videos/%s/%s/Subtitles/%s/%s/Stream.%s"
-            % (item_id, media_source_id, index, fmt_index, fmt), {})
+            % (item_id, media_source_id, index, fmt_index, fmt), {},
+            include_apikey=include_apikey)
 
-    def trickplay_tile_url(self, item_id, width, index, media_source_id=None):
+    def trickplay_tile_url(self, item_id, width, index, media_source_id=None,
+                           include_apikey=True):
         """Build the URL for a single trickplay (scrubbing preview) tile."""
         params = {}
         if media_source_id is not None:
             params["MediaSourceId"] = media_source_id
         return self._get_url(
-            "Videos/%s/Trickplay/%s/%s.jpg" % (item_id, width, index), params)
+            "Videos/%s/Trickplay/%s/%s.jpg" % (item_id, width, index), params,
+            include_apikey=include_apikey)
 
 
 class GranularAPIMixin:

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -756,16 +756,24 @@ class GranularAPIMixin:
     def get_random_items(self, parent_id=None, include_item_types=None,
                          limit=100, fields=None, image_types=None,
                          max_official_rating=None, enable_images=None,
-                         enable_total_record_count=None):
+                         enable_total_record_count=None, media_types=None):
         """A random sample of items, shuffled by the server (``SortBy=Random``)
         so it spans the whole library rather than one loaded page.
 
         ``image_types`` restricts the result to items that *have* that image
         (e.g. ``"Backdrop"`` when picking artwork), which is not the same as
         ``enable_image_types``.
+
+        ``media_types`` (``"Video,Audio"``) filters on what an item *is to a
+        player*, which for "give me something to queue" is usually a better
+        axis than ``include_item_types``: that one matches the concrete
+        entity the library scanner chose, so the answer depends on which
+        resolver ran (a clip in a Home Videos library is a ``Video``, the
+        same file in a movies library a ``Movie``).
         """
         return self.get_user_items(
             parent_id=parent_id, include_item_types=include_item_types,
+            media_types=media_types,
             recursive=True, sort_by="Random", limit=limit, fields=fields,
             enable_images=enable_images,
             enable_total_record_count=enable_total_record_count,

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -545,14 +545,26 @@ class GranularAPIMixin:
             start_index, limit, fields, image_type_limit, enable_image_types,
             search_term)
 
-    def get_instant_mix(self, item_id, limit=200):
+    def get_instant_mix(self, item_id, limit=200, fields=None):
         """A radio-style auto queue seeded from an item (GET
-        /Items/{id}/InstantMix); works for a song, album, artist, or genre."""
-        return self._get("Items/%s/InstantMix" % item_id, {
+        /Items/{id}/InstantMix); works for a song, album, artist, or genre.
+
+        ``fields`` defaults to the ``music_info()`` set for backwards
+        compatibility, but that set is expensive here in a way it is not on a
+        single item: ``MediaStreams``, ``People`` and ``ItemCounts`` are all
+        per-item lookups, and this endpoint returns up to ``limit`` (200)
+        items, so the server does hundreds of extra queries before it answers.
+        jellyfin-web asks for no fields at all here. Pass ``fields=""`` to do
+        the same, or a lean set of your own.
+        """
+        params = {
             "UserId": "{UserId}",
             "Limit": limit,
-            "Fields": music_info(),
-        })
+        }
+        fields = music_info() if fields is None else fields
+        if fields:
+            params["Fields"] = fields
+        return self._get("Items/%s/InstantMix" % item_id, params)
 
     def get_recommendation(self, parent_id=None, limit=20):
         return self._get("Movies/Recommendations", {

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -499,6 +499,31 @@ class GranularAPIMixin:
             params['Limit'] = limit
         return self.shows("/%s/Episodes" % series_id, params)
 
+    def get_studios(self, parent_id=None, include_item_types=None,
+                    sort_by="SortName", sort_order="Ascending",
+                    fields=None, start_index=None, limit=None):
+        """Studios / networks under a library (GET /Studios).
+
+        The by-name counterpart to ``get_genres``: it answers with Studio
+        items carrying their own ids and artwork, which is what a studios
+        screen draws and what ``StudioIds`` on an item query then filters by.
+        """
+        params = {
+            "ParentId": parent_id,
+            "UserId": "{UserId}",
+            "SortBy": sort_by,
+            "SortOrder": sort_order,
+            "Recursive": True,
+            "Fields": fields if fields is not None else "PrimaryImageAspectRatio",
+        }
+        if include_item_types is not None:
+            params["IncludeItemTypes"] = include_item_types
+        if start_index is not None:
+            params["StartIndex"] = start_index
+        if limit is not None:
+            params["Limit"] = limit
+        return self._get("Studios", params)
+
     def get_genres(self, parent_id=None, include_item_types=None):
         params = {
             'ParentId': parent_id,

--- a/jellyfin_apiclient_python/api.py
+++ b/jellyfin_apiclient_python/api.py
@@ -449,7 +449,13 @@ class GranularAPIMixin:
         return self.user_items("/Latest", params)
 
     def get_next(self, index=None, limit=1, series_id=None, fields=None,
-                 enable_image_types=None):
+                 enable_image_types=None, image_type_limit=None):
+        """Next Up (GET /Shows/NextUp).
+
+        ``image_type_limit`` caps how many tags of each type come back per
+        item. Without it a series with twenty backdrops sends twenty tags
+        for a card that will use one; jellyfin-web sends 1 here.
+        """
         params = {
             'Limit': limit,
             'UserId': "{UserId}",
@@ -461,6 +467,8 @@ class GranularAPIMixin:
             params['Fields'] = fields
         if enable_image_types is not None:
             params['EnableImageTypes'] = enable_image_types
+        if image_type_limit is not None:
+            params['ImageTypeLimit'] = image_type_limit
         return self.shows("/NextUp", params)
 
     def get_adjacent_episodes(self, show_id, item_id):

--- a/jellyfin_apiclient_python/http.py
+++ b/jellyfin_apiclient_python/http.py
@@ -81,15 +81,37 @@ class HTTP(object):
 
         return string
 
-    def request_url(self, data):
+    #: Query parameter carrying the access token on a built URL.
+    #:
+    #: ``ApiKey``, not ``api_key``: the server accepts the latter only while
+    #: ``EnableLegacyAuthorization`` is on, and it is off by default from
+    #: Jellyfin v12. Both are read in the same place
+    #: (``AuthorizationContext.GetAuthorizationInfoFromDictionary``), so this
+    #: is a spelling change and nothing more -- ``ApiKey`` has been accepted
+    #: since well before v12.
+    #:
+    #: Requests the client makes itself never rely on this. They carry
+    #: ``Authorization: MediaBrowser Token="…"``, which is the non-legacy
+    #: header scheme. This is only for URLs handed to something else -- a
+    #: media player, a downloader -- which issue their own requests.
+    APIKEY_PARAM = "ApiKey"
+
+    def request_url(self, data, include_apikey=True):
+        """Build a URL without issuing it.
+
+        ``include_apikey=False`` leaves the token out entirely, for callers
+        that can authenticate the eventual request themselves -- mpv takes
+        ``--http-header-fields``, for instance. Prefer it: a token in a URL
+        is a token in logs, in ``ps`` output and in any proxy in the path.
+        """
         if not data:
             raise AttributeError("Request cannot be empty")
 
         data = self._request(data)
 
         params = data["params"]
-        if "api_key" not in params:
-            params["api_key"] = self.config.data.get('auth.token')
+        if include_apikey and self.APIKEY_PARAM not in params:
+            params[self.APIKEY_PARAM] = self.config.data.get('auth.token')
 
         encoded_params = urllib.parse.urlencode(data["params"])
         return "%s?%s" % (data["url"], encoded_params)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -493,3 +493,69 @@ class TestImageStreams(RequestCaptureMixin, TestCase):
         request = self.request()
         assert request["handler"] == "Videos/item1/Trickplay/320/2.jpg"
         assert request["params"] == {"MediaSourceId": "src1"}
+
+
+class TestUrlTokenSpelling(TestCase):
+    """A built URL carries ``ApiKey``, not ``api_key``.
+
+    The server reads both in the same place
+    (``AuthorizationContext.GetAuthorizationInfoFromDictionary``), but
+    ``api_key`` is gated on ``EnableLegacyAuthorization`` -- off by default
+    from Jellyfin v12 -- while ``ApiKey`` is not. So this is a spelling
+    change and nothing more.
+
+    Requests the client issues itself never depended on this: they carry
+    ``Authorization: MediaBrowser Token="…"``, the non-legacy header scheme.
+    Only URLs handed to something else -- a media player, a downloader --
+    reach this code.
+    """
+
+    def _api(self):
+        client = Mock()
+        client.config.data = {"auth.server": "https://example.com",
+                              "auth.token": "T0KEN",
+                              "http.user_agent": "test/1.0",
+                              "http.timeout": 30,
+                              # audio_url substitutes {UserId}
+                              "auth.user_id": "U1",
+                              "app.device_id": "D1"}
+        return API(HTTP(client))
+
+    def test_a_built_url_uses_the_modern_spelling(self):
+        url = self._api().download_url("item1")
+        assert "ApiKey=T0KEN" in url
+        assert "api_key" not in url
+
+    def test_the_token_can_be_left_out_entirely(self):
+        """For callers that authenticate the eventual request themselves --
+        mpv takes --http-header-fields. A token in a URL is a token in logs,
+        in ps output and in every proxy in the path."""
+        url = self._api().download_url("item1", include_apikey=False)
+        assert "ApiKey" not in url
+        assert "api_key" not in url
+
+    def test_every_url_builder_can_be_switched_off(self):
+        api = self._api()
+        built = {
+            "artwork": api.artwork("i", "Primary", 100, include_apikey=False),
+            "audio_url": api.audio_url("i", include_apikey=False),
+            "video_url": api.video_url("i", include_apikey=False),
+            "download_url": api.download_url("i", include_apikey=False),
+            "image_url": api.image_url("i", include_apikey=False),
+            "subtitle_url": api.subtitle_url("i", "s", 1, "srt",
+                                             include_apikey=False),
+            "trickplay_tile_url": api.trickplay_tile_url(
+                "i", 320, 0, include_apikey=False),
+        }
+        for name, url in built.items():
+            assert "ApiKey" not in url, name
+            assert "api_key" not in url, name
+
+    def test_and_carries_it_by_default(self):
+        api = self._api()
+        for url in (api.artwork("i", "Primary", 100), api.audio_url("i"),
+                    api.video_url("i"), api.download_url("i"),
+                    api.image_url("i"),
+                    api.subtitle_url("i", "s", 1, "srt"),
+                    api.trickplay_tile_url("i", 320, 0)):
+            assert "ApiKey=T0KEN" in url


### PR DESCRIPTION
This API client still provided URLs using `api_key`, which is dead in the next jellyfin release. Also added `include_apikey` param, defaulting to true, which allows generating URLs without the api key if you wish to use header auth instead.

Other incidental changes folded in:
- `get_next` gets an optional `image_type_limit` to avoid requesting excessive numbers of image backdrops.
- `get_studios` added for fetching a list of TV studios.
- `get_instant_mix` gets a `fields` option so you can opt out of requesting drilldown fields.
- `get_random_items` gets `media_types` so you can opt into a specific set of media types.

The new style ApiKey param is confirmed to work in older Jellyfin versions exceeding 1 year old, so no breaking change revision is being added to this API. All other changes are additive. 
